### PR TITLE
Add UPCL League section with standings and fixtures

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -150,6 +150,7 @@ h2{margin:0 0 10px}
     <button id="navFixturesPublic" aria-pressed="false">Fixtures</button>
     <button id="navFixturesSched"  aria-pressed="false" style="display:none">Scheduling</button>
     <button id="navChampions" aria-pressed="false">Champions Cup</button>
+    <button id="navLeague" aria-pressed="false">UPCL League</button>
     <button id="btnManagerLogin">Manager sign in</button>
     <button id="btnAdminLogin">Admin sign in</button>
     <button id="btnAdminLogout" style="display:none">Admin sign out</button>
@@ -325,6 +326,67 @@ h2{margin:0 0 10px}
       <div id="ccFixtures" class="fx-list" style="margin-top:8px"></div>
     </div>
   </section>
+
+  <!-- UPCL LEAGUE -->
+  <section id="league-view" style="display:none">
+    <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap">
+      <h2>UPCL League</h2>
+      <div class="chip">League ID: <span id="leagueCupId"></span></div>
+    </div>
+
+    <div class="m-card" style="margin-top:10px">
+      <strong>Standings</strong>
+      <div id="leagueTable" style="margin-top:8px"></div>
+    </div>
+
+    <div class="m-card" style="margin-top:10px">
+      <strong>Leaders</strong>
+      <div id="leagueLeaders" style="margin-top:8px;display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:16px"></div>
+    </div>
+
+    <div class="m-card" id="leagueAdmin" style="display:none;margin-top:10px">
+      <strong>Admin tools</strong>
+      <div class="muted">Manage league teams and create fixtures.</div>
+      <div id="leagueTeamList" style="margin-top:8px"></div>
+      <div style="margin-top:8px;display:flex;gap:8px;flex-wrap:wrap">
+        <select id="leagueAddSel"></select>
+        <button id="leagueAddBtn">Add team</button>
+      </div>
+
+      <hr style="border:none;border-top:1px solid #220000;margin:12px 0">
+
+      <div>
+        <strong>Create League fixture</strong>
+        <div class="grid2" style="margin-top:8px">
+          <div>
+            <label class="muted">Home</label>
+            <select id="leagueHomeSel"></select>
+          </div>
+          <div>
+            <label class="muted">Away</label>
+            <select id="leagueAwaySel"></select>
+          </div>
+          <div>
+            <label class="muted">Stage / Round</label>
+            <input id="leagueRoundInput" placeholder="e.g., Week 1">
+          </div>
+          <div>
+            <label class="muted">Date & time (optional)</label>
+            <input id="leagueWhenInput" type="datetime-local">
+          </div>
+          <div style="align-self:end">
+            <button id="leagueFormCreate">Create fixture</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="m-card" style="margin-top:10px">
+      <strong>League Fixtures</strong>
+      <div id="leagueFixtures" class="fx-list" style="margin-top:8px"></div>
+    </div>
+  </section>
+
 </main>
 
 <!-- Manager Sign-In Modal -->
@@ -417,6 +479,7 @@ h2{margin:0 0 10px}
 // =======================
 const API_BASE = '';
 const CC_ID = 'UPCL_CC_2025_08'; // current Champions Cup id
+const LEAGUE_ID = 'UPCL_LEAGUE_2025'; // current League id
 
 const TEAM_TITLES = {
   '3638105': [
@@ -480,6 +543,7 @@ const navMarket   = document.getElementById('navMarket');
 const navFxPublic = document.getElementById('navFixturesPublic');
 const navFxSched  = document.getElementById('navFixturesSched');
 const navChampions= document.getElementById('navChampions');
+const navLeague   = document.getElementById('navLeague');
 
 const teamsViewEl = document.getElementById('teams-view');
 const newsView    = document.getElementById('news-view');
@@ -487,6 +551,7 @@ const marketView  = document.getElementById('market-view');
 const fxPublic    = document.getElementById('fixtures-public');
 const fxSched     = document.getElementById('fixtures-sched');
 const cupView     = document.getElementById('champions-view');
+const leagueView  = document.getElementById('league-view');
 
 function setNav(active){
   if (active==='fixturesSched' && !(isMgr || isAdmin)) { alert('Managers only'); active='fixturesPublic'; }
@@ -496,7 +561,8 @@ function setNav(active){
     market:[marketView, navMarket],
     fixturesPublic:[fxPublic, navFxPublic],
     fixturesSched:[fxSched, navFxSched],
-    champions:[cupView, navChampions]
+    champions:[cupView, navChampions],
+    league:[leagueView, navLeague]
   };
   for (const key of Object.keys(s)){
     const [view,btn] = s[key];
@@ -511,6 +577,7 @@ navMarket.onclick      = ()=> setNav('market');
 navFxPublic.onclick    = ()=> setNav('fixturesPublic');
 navFxSched.onclick     = ()=> setNav('fixturesSched');
 navChampions.onclick   = async ()=> { setNav('champions'); await loadChampions(); };
+navLeague.onclick      = async ()=> { setNav('league'); await loadLeague(); };
 
 // auth / admin / manager
 const btnAdminLogin = document.getElementById('btnAdminLogin');
@@ -1350,6 +1417,76 @@ function setupCcFixtureForm(){
       await apiPost('/api/cup/fixtures', { home, away, round, cup: CC_ID, group, when });
       alert('Fixture created'); await loadChampions();
     }catch(e){ alert('Create failed: '+e.message); }
+  };
+}
+
+async function loadLeague(){
+  document.getElementById('leagueCupId').textContent = LEAGUE_ID;
+
+  let leagueData = { league:{ teams:[] }, standings:[] };
+  try { leagueData = await apiGet(`/api/leagues/${encodeURIComponent(LEAGUE_ID)}`); } catch {}
+  renderLeagueTable(leagueData.standings);
+
+  try { const leaders = await apiGet(`/api/leagues/${encodeURIComponent(LEAGUE_ID)}/leaders`); renderLeagueLeaders(leaders); } catch {}
+
+  let fxList = [];
+  try { const fx = await apiGet(`/api/cup/fixtures?cup=${encodeURIComponent(LEAGUE_ID)}`); fxList = fx.fixtures || []; } catch {}
+  renderLeagueFixtures(fxList);
+
+  document.getElementById('leagueAdmin').style.display = isAdmin ? 'block' : 'none';
+  if (isAdmin) buildLeagueAdmin(leagueData.league.teams);
+}
+
+function renderLeagueTable(rows){
+  const el = document.getElementById('leagueTable');
+  if (!rows.length){ el.innerHTML = '<div class="muted">No standings yet.</div>'; return; }
+  el.innerHTML = `<table class="group-table"><thead><tr><th>Club</th><th>P</th><th>W</th><th>D</th><th>L</th><th>GF</th><th>GA</th><th>GD</th><th>Pts</th></tr></thead><tbody>${rows.map(r=>{ const T=byId(r.clubId); return `<tr><td><span class="group-team"><img src="${teamLogoUrl(T)}" alt=""><span>${escapeHtml(T?.name||r.clubId)}</span></span></td><td>${r.P}</td><td>${r.W}</td><td>${r.D}</td><td>${r.L}</td><td>${r.GF}</td><td>${r.GA}</td><td>${r.GD}</td><td>${r.Pts}</td></tr>`; }).join('')}</tbody></table>`;
+}
+
+function renderLeagueLeaders(data){
+  const wrap = document.getElementById('leagueLeaders');
+  const scorers = (data?.scorers||[]).map(r=>{ const T=byId(r.clubId); const club=T?.shortName||T?.name||r.clubId; return `<li>${escapeHtml(r.name)} <span class="muted">(${r.count}) - ${escapeHtml(club)}</span></li>`; }).join('');
+  const assisters = (data?.assisters||[]).map(r=>{ const T=byId(r.clubId); const club=T?.shortName||T?.name||r.clubId; return `<li>${escapeHtml(r.name)} <span class="muted">(${r.count}) - ${escapeHtml(club)}</span></li>`; }).join('');
+  if (!scorers && !assisters){ wrap.innerHTML = '<div class="muted">No stats yet.</div>'; return; }
+  wrap.innerHTML = `<div><div class="muted">Top Scorers</div><ol style="margin-top:6px;padding-left:18px">${scorers||''}</ol></div><div><div class="muted">Top Assisters</div><ol style="margin-top:6px;padding-left:18px">${assisters||''}</ol></div>`;
+}
+
+function renderLeagueFixtures(list){
+  const el = document.getElementById('leagueFixtures');
+  list.sort((a,b)=>(a.when||a.createdAt)-(b.when||b.createdAt));
+  el.innerHTML = list.length ? list.map(f=>{ const H=byId(f.home), A=byId(f.away); const hn=H?.name||f.home; const an=A?.name||f.away; const whenTxt=f.when?fmtDate(f.when):'TBD'; const scoreTxt=(f.status==='final')?`${f.score.hs}–${f.score.as}`:'vs'; const banner=getFixtureBanner(); const editBtn = isAdmin ? `<div class="act"><button data-lq="${f.id}">Quick Edit</button></div>` : ''; return `<div class="fx" id="lffx_${f.id}"><div>${banner?`<img class="fx-banner" src="${banner}" alt="">`:''}<div class="fx-vs"><span class="fx-team"><img src="${teamLogoUrl(H)}" alt=""><span>${escapeHtml(hn)}</span></span><span class="muted">${scoreTxt}</span><span class="fx-team"><img src="${teamLogoUrl(A)}" alt=""><span>${escapeHtml(an)}</span></span></div><div class="meta"><span class="chip">UPCL League${f.round?` • ${escapeHtml(f.round)}`:''}</span> • ${whenTxt} • ${escapeHtml(f.status||'')}</div></div>${editBtn}</div>`; }).join('') : `<div class="muted">No league fixtures yet.</div>`;
+  list.forEach(f=>{ const q=document.querySelector(`[data-lq="${f.id}"]`); if(q) q.onclick=()=> openResultEditor(f); });
+}
+
+function buildLeagueAdmin(teamIds){
+  const listEl = document.getElementById('leagueTeamList');
+  listEl.innerHTML = teamIds.length ? teamIds.map(id=>{ const T=byId(id); return `<div style="margin-top:4px"><span>${escapeHtml(T?.name||id)}</span> <button data-remove="${id}">Remove</button></div>`; }).join('') : '<div class="muted">No teams.</div>';
+  listEl.querySelectorAll('[data-remove]').forEach(btn=>{ btn.onclick = async ()=>{ const id = btn.getAttribute('data-remove'); const next = teamIds.filter(t=>t!==id); try{ await apiPost(`/api/leagues/${LEAGUE_ID}/teams`, { teams: next }); await loadLeague(); }catch(e){ alert('Update failed: '+e.message); } }; });
+  const addSel = document.getElementById('leagueAddSel'); const addBtn = document.getElementById('leagueAddBtn');
+  const options = teams.filter(t=>!teamIds.includes(t.id)).map(t=>`<option value="${t.id}">${escapeHtml(t.name)} (${t.id})</option>`).join('');
+  addSel.innerHTML = `<option value="">— choose —</option>${options}`;
+  addBtn.onclick = async ()=>{ const id = addSel.value; if(!id) return alert('Pick a team'); const next=[...teamIds,id]; try{ await apiPost(`/api/leagues/${LEAGUE_ID}/teams`, { teams: next }); await loadLeague(); }catch(e){ alert('Update failed: '+e.message); } };
+  setupLeagueFixtureForm(teamIds);
+}
+
+function setupLeagueFixtureForm(teamIds){
+  const homeSel=document.getElementById('leagueHomeSel');
+  const awaySel=document.getElementById('leagueAwaySel');
+  const roundInput=document.getElementById('leagueRoundInput');
+  const whenInput=document.getElementById('leagueWhenInput');
+  const createBtn=document.getElementById('leagueFormCreate');
+  if(!homeSel||!awaySel||!createBtn) return;
+  const opts=teamIds.map(id=>{ const T=byId(id); return `<option value="${id}">${escapeHtml(T?.name||id)}</option>`; }).join('');
+  homeSel.innerHTML=`<option value="">— choose —</option>${opts}`;
+  awaySel.innerHTML=`<option value="">— choose —</option>${opts}`;
+  function ensureDifferent(){ if(homeSel.value && awaySel.value && homeSel.value===awaySel.value){ alert('Home and away cannot be the same club.'); awaySel.value=''; } }
+  homeSel.onchange=ensureDifferent; awaySel.onchange=ensureDifferent;
+  createBtn.onclick=async ()=>{
+    const home=homeSel.value; const away=awaySel.value; const round=(roundInput.value||'').trim()||'Round';
+    const when=whenInput.value?Date.parse(whenInput.value):null;
+    if(!home||!away) return alert('Pick both teams');
+    try{ await apiPost('/api/cup/fixtures', { home, away, round, cup: LEAGUE_ID, when }); alert('Fixture created'); await loadLeague(); }
+    catch(e){ alert('Create failed: '+e.message); }
   };
 }
 


### PR DESCRIPTION
## Summary
- add server endpoints for UPCL League standings, leaders, and team management
- introduce UPCL League client section with standings, top players, admin team controls, and fixture creator

## Testing
- `node --check server.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e91ea9bb0832e9c2b92f9d8187754