### PR TITLE
fix: update intro audio format

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -157,7 +157,7 @@ h2{margin:0 0 10px}
 <body>
 <div id="intro">
     <img src="/assets/logos/UPCL.png" alt="League logo">
-  <audio id="introAudio" src="/assets/intro.wav"></audio>
+  <audio id="introAudio" src="/assets/intro.mp3"></audio>
 </div>
 <header>
   <h1>Pro Club — League Hub</h1>


### PR DESCRIPTION
## Summary
- point teams page intro to intro.mp3 instead of missing intro.wav

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fbc7d3bec832e940913cb97c0ffd4