### PR TITLE
Replace club IDs in news items with club names

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -1657,6 +1657,11 @@ function renderNewsItem(n){
       body  = 'Full time score';
     }
   }
+  if (club && n.clubId){
+    const cid = String(n.clubId);
+    if (title && title.includes(cid)){ title = title.replaceAll(cid, club.name); }
+    if (body  && body.includes(cid)){ body  = body.replaceAll(cid, club.name); }
+  }
   return `<article class="news-post">
     <img class="news-avatar" src="${teamLogoUrl(club)}" alt="">
     <div class="news-body">


### PR DESCRIPTION
## Summary
- Ensure news item titles and bodies show human-readable club names by replacing raw club IDs

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689feb9d3180832e9ec178aebc54457a