### PR TITLE
Add dark fallback for teams page background

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -17,6 +17,7 @@
 html,body{height:100%}
 body{
   background: radial-gradient(circle at top, #300000, #000000 70%), url('assets/stars.svg');
+  background-color:#000;
   background-size: cover, auto; background-repeat: no-repeat, repeat;
   color:#fff;font-family:'Montserrat',Arial,system-ui,-apple-system,Segoe UI,sans-serif;
   margin:0; min-height:100vh; -webkit-text-size-adjust:100%;


### PR DESCRIPTION
## Summary
- ensure `teams.html` uses a dark fallback background color

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ffab732d0832e9df28374432f9f1e