### PR TITLE
Remove star background from teams page

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -16,9 +16,9 @@
 *{box-sizing:border-box}
 html,body{height:100%}
 body{
-  background: radial-gradient(circle at top, #300000, #000000 70%), url('assets/stars.svg');
+  background: radial-gradient(circle at top, #300000, #000000 70%);
   background-color:#000;
-  background-size: cover, auto; background-repeat: no-repeat, repeat;
+  background-size: cover; background-repeat: no-repeat;
   color:#fff;font-family:'Montserrat',Arial,system-ui,-apple-system,Segoe UI,sans-serif;
   margin:0; min-height:100vh; -webkit-text-size-adjust:100%;
 }


### PR DESCRIPTION
## Summary
- Remove repeating stars background from teams page for consistent look

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fffa66d60832e96e646107d5b3ae3