### PR TITLE
Normalize club IDs and enforce duplicate checks

### DIFF
--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -27,3 +27,9 @@ test('duplicate ids across groups are detected', () => {
   const all = [...docGroups.A, ...docGroups.B, ...docGroups.C, ...docGroups.D];
   assert.strictEqual(hasDuplicates(all), true);
 });
+
+test('formatted ids normalize to detect duplicates', () => {
+  const variants = ['Elite-xi', 'elite xi'];
+  assert.strictEqual(hasDuplicates(variants), true);
+  assert.deepStrictEqual(uniqueStrings(variants), ['elitexi']);
+});

--- a/utils.js
+++ b/utils.js
@@ -1,10 +1,14 @@
+function normalizeId(id){
+  return String(id || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
 function uniqueStrings(arr){
-  return Array.from(new Set((arr||[]).map(id => String(id))));
+  return Array.from(new Set((arr || []).map(normalizeId)));
 }
 
 function hasDuplicates(arr){
-  const ids = (arr||[]).map(id => String(id));
+  const ids = (arr || []).map(normalizeId);
   return new Set(ids).size !== ids.length;
 }
 
-module.exports = { uniqueStrings, hasDuplicates };
+module.exports = { uniqueStrings, hasDuplicates, normalizeId };


### PR DESCRIPTION
## Summary
- add `normalizeId` helper and use it in `uniqueStrings` & `hasDuplicates`
- reject duplicates in Champions Cup group endpoints after normalizing IDs
- test ID normalization so differently formatted IDs collide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0f34c874c832e9eb196438d275c0c