### PR TITLE
Keep original IDs when deduplicating

### DIFF
--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -7,8 +7,8 @@ test('hasDuplicates detects duplicates', () => {
   assert.strictEqual(hasDuplicates(['1','2','3']), false);
 });
 
-test('uniqueStrings strips duplicates and coerces to string', () => {
-  assert.deepStrictEqual(uniqueStrings([1,'1',2]), ['1','2']);
+test('uniqueStrings strips duplicates and preserves originals', () => {
+  assert.deepStrictEqual(uniqueStrings([1,'1',2]), [1,2]);
 });
 
 test('duplicate ids across groups are detected', () => {
@@ -31,5 +31,5 @@ test('duplicate ids across groups are detected', () => {
 test('formatted ids normalize to detect duplicates', () => {
   const variants = ['Elite-xi', 'elite xi'];
   assert.strictEqual(hasDuplicates(variants), true);
-  assert.deepStrictEqual(uniqueStrings(variants), ['elitexi']);
+  assert.deepStrictEqual(uniqueStrings(variants), ['Elite-xi']);
 });

--- a/utils.js
+++ b/utils.js
@@ -3,7 +3,16 @@ function normalizeId(id){
 }
 
 function uniqueStrings(arr){
-  return Array.from(new Set((arr || []).map(normalizeId)));
+  const seen = new Set();
+  const result = [];
+  for (const id of arr || []) {
+    const norm = normalizeId(id);
+    if (!seen.has(norm)) {
+      seen.add(norm);
+      result.push(id);
+    }
+  }
+  return result;
 }
 
 function hasDuplicates(arr){


### PR DESCRIPTION
## Summary
- preserve original IDs while using normalized values to filter duplicates in `uniqueStrings`
- adjust tests to verify original IDs are returned and normalization still detects duplicates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f95157d4832e8519675a39870f5d