### PR TITLE
feat: allow editing existing champions cup groups

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -1480,14 +1480,24 @@ function buildManualGroupsEditor(groups){
   const root = document.getElementById('ccManualGroups');
   const opts = teams.map(t=> `<option value="${t.id}">${escapeHtml(t.name)} (${t.id})</option>`).join('');
   root.innerHTML = ['A','B','C','D'].map(g=>{
-    const rows = (groups[g]||[]).length
-      ? (groups[g]||[]).map(v=>`<div><select>${opts}</select></div>`).join('')
-      : '';
+    const rows = (groups[g]||[]).map(v=>
+      `<div class="grow"><select data-val="${v}">${opts}</select> <button data-rm>X</button></div>`
+    ).join('');
     return `<div class="m-card"><strong>Group ${g}</strong>
       <div data-g="${g}" class="gbox">${rows}</div>
       <div style="margin-top:6px"><button data-add="${g}">+ Add team</button></div>
     </div>`;
   }).join('');
+
+  root.querySelectorAll('select[data-val]').forEach(sel=>{
+    sel.value = sel.getAttribute('data-val');
+  });
+
+  function attachRemove(btn){
+    if(!btn) return;
+    btn.onclick = ()=> btn.parentElement.remove();
+  }
+  root.querySelectorAll('[data-rm]').forEach(attachRemove);
 
   // add rows
   root.querySelectorAll('[data-add]').forEach(btn=>{
@@ -1495,8 +1505,10 @@ function buildManualGroupsEditor(groups){
       const g = btn.getAttribute('data-add');
       const box = root.querySelector(`.gbox[data-g="${g}"]`);
       const div = document.createElement('div');
-      div.innerHTML = `<div><select>${opts}</select></div>`;
+      div.className = 'grow';
+      div.innerHTML = `<select>${opts}</select> <button data-rm>X</button>`;
       box.appendChild(div);
+      attachRemove(div.querySelector('[data-rm]'));
     };
   });
 

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ const path = require('path');
 const session = require('express-session');
 const bcrypt = require('bcryptjs');
 const { v4: uuidv4 } = require('uuid');
-const { hasDuplicates, uniqueStrings, normalizeId } = require('./utils');
+const { hasDuplicates, uniqueStrings } = require('./utils');
 
 let helmet = null, compression = null, cors = null, morgan = null;
 try { helmet = require('helmet'); } catch {}
@@ -1111,7 +1111,7 @@ app.post('/api/champions/:cupId/randomize', requireAdmin, wrap(async (req,res)=>
   shuffle(clubs);
   const groups = { A:[], B:[], C:[], D:[] };
   // Distribute round-robin into A-D; supports any multiple, not only 16
-  clubs.forEach((id,i)=> groups[['A','B','C','D'][i%4]].push(normalizeId(id)));
+  clubs.forEach((id,i)=> groups[['A','B','C','D'][i%4]].push(id));
   const doc = { cupId, groups, createdAt: Date.now() };
   await COL.champions().doc(cupId).set(doc);
   res.json({ ok:true, cup:doc });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -7,8 +7,8 @@ test('hasDuplicates detects duplicates', () => {
   assert.strictEqual(hasDuplicates(['1','2','3']), false);
 });
 
-test('uniqueStrings strips duplicates and coerces to string', () => {
-  assert.deepStrictEqual(uniqueStrings([1,'1',2]), ['1','2']);
+test('uniqueStrings strips duplicates and retains original values', () => {
+  assert.deepStrictEqual(uniqueStrings([1,'1',2]), [1,2]);
 });
 
 test('duplicate ids across groups are detected', () => {
@@ -31,5 +31,5 @@ test('duplicate ids across groups are detected', () => {
 test('formatted ids normalize to detect duplicates', () => {
   const variants = ['Elite-xi', 'elite xi'];
   assert.strictEqual(hasDuplicates(variants), true);
-  assert.deepStrictEqual(uniqueStrings(variants), ['elitexi']);
+  assert.deepStrictEqual(uniqueStrings(variants), ['Elite-xi']);
 });

--- a/utils.js
+++ b/utils.js
@@ -3,7 +3,16 @@ function normalizeId(id){
 }
 
 function uniqueStrings(arr){
-  return Array.from(new Set((arr || []).map(normalizeId)));
+  const seen = new Set();
+  const out = [];
+  for (const id of arr || []) {
+    const norm = normalizeId(id);
+    if (!seen.has(norm)) {
+      seen.add(norm);
+      out.push(id);
+    }
+  }
+  return out;
 }
 
 function hasDuplicates(arr){


### PR DESCRIPTION
## Summary
- show existing Champions Cup group teams with remove buttons
- return original IDs from `uniqueStrings`
- update utils tests for new ID handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f61fb3b8832ea9c3b5b00966183a