### PR TITLE
feat: fetch EA league matches in batch

### DIFF
--- a/services/eaApi.js
+++ b/services/eaApi.js
@@ -1,13 +1,21 @@
 const fetchFn = global.fetch || ((...a) => import('node-fetch').then(m => m.default(...a)));
 
-async function fetchRecentLeagueMatches(clubId){
-  if(!clubId) throw new Error('clubId required');
-  const url = `https://proclubs.ea.com/api/fc/matches?matchType=league&clubIds=${clubId}`;
+async function fetchClubLeagueMatches(clubIds) {
+  const ids = Array.isArray(clubIds) ? clubIds : [clubIds];
+  if (!ids.length) throw new Error('clubIds required');
+  const url =
+    `https://proclubs.ea.com/api/fc/clubs/matches?matchType=leagueMatch` +
+    `&platform=common-gen5&clubIds=${ids.join(',')}`;
   const res = await fetchFn(url);
-  if(!res.ok){
+  if (!res.ok) {
     throw new Error(`EA API error ${res.status}`);
   }
   return res.json();
 }
 
-module.exports = { fetchRecentLeagueMatches };
+async function fetchRecentLeagueMatches(clubId) {
+  const data = await fetchClubLeagueMatches([clubId]);
+  return data?.[clubId] || [];
+}
+
+module.exports = { fetchClubLeagueMatches, fetchRecentLeagueMatches };


### PR DESCRIPTION
## Summary
- batch fetch EA league matches for league teams
- expand EA API service with multi-club support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3cf76e8a0832eb2f63593af391992