### PR TITLE
Add fixture export script and champions stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/scripts/exportCupFixtures.js
+++ b/scripts/exportCupFixtures.js
@@ -1,0 +1,36 @@
+const admin = require('firebase-admin');
+const pool = require('../db');
+
+async function main(){
+  const cupId = process.argv[2];
+  if (!cupId){
+    console.error('Usage: node scripts/exportCupFixtures.js <cupId>');
+    process.exit(1);
+  }
+  if (!process.env.FIREBASE_SERVICE_ACCOUNT){
+    throw new Error('FIREBASE_SERVICE_ACCOUNT env var is required');
+  }
+  const svc = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT);
+  if (svc.private_key && svc.private_key.includes('\\n')){
+    svc.private_key = svc.private_key.replace(/\\n/g, '\n');
+  }
+  if (!admin.apps.length){
+    admin.initializeApp({ credential: admin.credential.cert(svc) });
+  }
+  const db = admin.firestore();
+
+  const snap = await db.collection('fixtures').where('cup','==',cupId).get();
+  console.log(`Found ${snap.size} fixtures for cup ${cupId}`);
+  for (const doc of snap.docs){
+    const f = { id:doc.id, ...doc.data() };
+    await pool.query(
+      `INSERT INTO fixtures (id, home, away, score, status, league_id, played_at, details)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+       ON CONFLICT (id) DO NOTHING`,
+      [f.id, f.home, f.away, f.score || null, f.status || null, f.cup || f.league_id || null, f.played_at || null, f]
+    );
+  }
+  await pool.end();
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/server.js
+++ b/server.js
@@ -1330,7 +1330,9 @@ app.get('/api/champions/:cupId', wrap(async (req,res)=>{
   const snap = await COL.champions().doc(cupId).get();
   const cup = snap.exists ? snap.data() : { cupId, groups:{A:[],B:[],C:[],D:[]}, createdAt: Date.now() };
   const tables = await computeGroupTables(cupId, cup.groups);
-  res.json({ ok:true, cup, tables });
+  const { rows } = await pool.query('SELECT COUNT(*) FROM fixtures WHERE league_id = $1', [cupId]);
+  const stats = { fixtureCount: Number(rows[0]?.count || 0) };
+  res.json({ ok:true, cup, tables, stats });
 }));
 
 // Leaders (Top scorers / assisters) — limit via ?limit=5


### PR DESCRIPTION
## Summary
- add helper to migrate Champions Cup fixtures from Firestore to Postgres
- expose fixture count stats in `/api/champions/:cupId`

## Testing
- `npm test`
- `node scripts/exportCupFixtures.js TEST_CUP` *(fails: Cannot find module 'firebase-admin')*
- `npm install firebase-admin` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a4174a7b8c832e825a731e9ffdaeff