### PR TITLE
Proxy EA club members fetch through server

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -623,10 +623,7 @@ async function resolvePlayerName(id){
 }
 
 async function fetchClubMembers(clubId){
-  const url = `https://proclubs.ea.com/api/fc/members/stats?platform=common-gen5&clubId=${encodeURIComponent(clubId)}`;
-  const res = await fetch(url);
-  if(!res.ok) throw new Error('EA API error');
-  return res.json();
+  return apiGet(`/api/ea/clubs/${encodeURIComponent(clubId)}/members`);
 }
 
 // nav elements

--- a/server.js
+++ b/server.js
@@ -13,7 +13,7 @@ const bcrypt = require('bcryptjs');
 const { v4: uuidv4 } = require('uuid');
 const { hasDuplicates, uniqueStrings } = require('./utils');
 const pool = require('./db');
-const { fetchClubLeagueMatches } = require('./services/eaApi');
+const { fetchClubLeagueMatches, fetchClubMembers } = require('./services/eaApi');
 
 let helmet = null, compression = null, cors = null, morgan = null;
 try { helmet = require('helmet'); } catch {}
@@ -430,6 +430,14 @@ app.post('/api/wallets/:clubId/collect', requireManagerOfClubParam('clubId'), wr
   });
   const preview = await collectPreview(clubId);
   res.json({ ...result, preview });
+}));
+
+// Proxy to fetch club members from EA API (avoids browser CORS)
+app.get('/api/ea/clubs/:clubId/members', wrap(async (req,res)=>{
+  const { clubId } = req.params;
+  if (!/^\d+$/.test(String(clubId))) return res.status(400).json({ error:'Invalid clubId' });
+  const data = await fetchClubMembers(clubId);
+  res.json(data);
 }));
 
 // -----------------------------

--- a/services/eaApi.js
+++ b/services/eaApi.js
@@ -18,4 +18,15 @@ async function fetchRecentLeagueMatches(clubId) {
   return data?.[clubId] || [];
 }
 
-module.exports = { fetchClubLeagueMatches, fetchRecentLeagueMatches };
+async function fetchClubMembers(clubId) {
+  if (!clubId) throw new Error('clubId required');
+  const url =
+    `https://proclubs.ea.com/api/fc/members/stats?platform=common-gen5&clubId=${encodeURIComponent(clubId)}`;
+  const res = await fetchFn(url);
+  if (!res.ok) {
+    throw new Error(`EA API error ${res.status}`);
+  }
+  return res.json();
+}
+
+module.exports = { fetchClubLeagueMatches, fetchRecentLeagueMatches, fetchClubMembers };


### PR DESCRIPTION
## Summary
- add EA API helper to fetch club members
- expose `/api/ea/clubs/:clubId/members` endpoint to proxy requests
- update frontend squad loader to call the new server endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4fc8d1afc832e9688173d656761e8