### PR TITLE
Gracefully handle EA API timeouts and failures

### DIFF
--- a/server.js
+++ b/server.js
@@ -436,8 +436,16 @@ app.post('/api/wallets/:clubId/collect', requireManagerOfClubParam('clubId'), wr
 app.get('/api/ea/clubs/:clubId/members', wrap(async (req,res)=>{
   const { clubId } = req.params;
   if (!/^\d+$/.test(String(clubId))) return res.status(400).json({ error:'Invalid clubId' });
-  const data = await fetchClubMembers(clubId);
-  res.json(data);
+  try {
+    const data = await fetchClubMembers(clubId);
+    res.json(data);
+  } catch (err) {
+    if (err?.error === 'EA API request timed out') {
+      res.status(504).json(err);
+    } else {
+      res.status(502).json(err?.error ? err : { error: 'EA API error' });
+    }
+  }
 }));
 
 // -----------------------------

--- a/services/eaApi.js
+++ b/services/eaApi.js
@@ -17,9 +17,15 @@ async function fetchClubLeagueMatches(clubIds) {
       signal: controller.signal
     });
     if (!res.ok) {
-      throw new Error(`EA API error ${res.status}`);
+      throw { error: 'EA API error', status: res.status };
     }
     return res.json();
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      throw { error: 'EA API request timed out' };
+    }
+    if (err && err.error) throw err;
+    throw { error: 'EA API error' };
   } finally {
     clearTimeout(timeout);
   }
@@ -45,9 +51,15 @@ async function fetchClubMembers(clubId) {
       signal: controller.signal
     });
     if (!res.ok) {
-      throw new Error(`EA API error ${res.status}`);
+      throw { error: 'EA API error', status: res.status };
     }
     return res.json();
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      throw { error: 'EA API request timed out' };
+    }
+    if (err && err.error) throw err;
+    throw { error: 'EA API error' };
   } finally {
     clearTimeout(timeout);
   }


### PR DESCRIPTION
## Summary
- throw structured errors from EA API helpers on timeouts or network/HTTP failures
- return 502/504 from club members proxy when EA API fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a50bee5950832eac3acc9b304d7155