### PR TITLE
feat: add fetch players for club

### DIFF
--- a/services/eaApi.js
+++ b/services/eaApi.js
@@ -66,4 +66,40 @@ async function fetchClubMembers(clubId) {
   }
 }
 
-module.exports = { fetchClubLeagueMatches, fetchRecentLeagueMatches, fetchClubMembers };
+async function fetchPlayersForClub(clubId) {
+  if (!clubId) throw new Error('clubId required');
+  const url =
+    `https://proclubs.ea.com/api/fc/clubs/${encodeURIComponent(
+      clubId
+    )}/members?platform=common-gen5`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': 'fc-26-project-beta',
+        Accept: 'application/json'
+      },
+      signal: controller.signal
+    });
+    if (!res.ok) {
+      throw { error: 'EA API error', status: res.status };
+    }
+    return res.json();
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      throw { error: 'EA API request timed out' };
+    }
+    if (err && err.error) throw err;
+    throw { error: 'EA API error' };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+module.exports = {
+  fetchClubLeagueMatches,
+  fetchRecentLeagueMatches,
+  fetchClubMembers,
+  fetchPlayersForClub
+};


### PR DESCRIPTION
## Summary
- add `fetchPlayersForClub` to call Pro Clubs members API with timeout handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a512ede600832e879192f75f190a03