### PR TITLE
Add API endpoint to aggregate club players

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# FC-26 Project Beta
+
+## API
+
+### `GET /api/players`
+
+Returns players from one or more EA Pro Clubs. Provide club IDs as a comma-separated
+`clubId` query parameter, e.g. `/api/players?clubId=123,456`.
+
+The server fetches each club, maps position codes using `proPos`, removes duplicates by
+name, and responds with the combined player list.


### PR DESCRIPTION
## Summary
- expose `/api/players` to fetch players from multiple EA club IDs
- map EA position codes with `proPos` and de-duplicate by name
- document the new route in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a513a900c4832e9be91c780582dd5f