### PR TITLE
Normalize EA member responses and update EA fetch

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -623,7 +623,14 @@ async function resolvePlayerName(id){
 }
 
 async function fetchClubMembers(clubId){
-  return apiGet(`/api/ea/clubs/${encodeURIComponent(clubId)}/members`);
+  if (!/^\d+$/.test(String(clubId))) return { members: [] };
+  const raw = await apiGet(`/api/ea/clubs/${encodeURIComponent(clubId)}/members`);
+  if (Array.isArray(raw)) return { members: raw };
+  if (Array.isArray(raw?.members)) return raw;
+  if (raw?.members && typeof raw.members === 'object') {
+    return { members: Object.values(raw.members) };
+  }
+  return { members: [] };
 }
 
 // nav elements
@@ -823,8 +830,7 @@ async function loadSquad(clubId){
   }
 
   try{
-    const data = await fetchClubMembers(clubId);
-    const members = Object.values(data.members || {});
+    const { members } = await fetchClubMembers(clubId);
     if (!members.length){
       body.innerHTML = '<div class="muted">No players found.</div>';
       return;

--- a/services/eaApi.js
+++ b/services/eaApi.js
@@ -1,5 +1,8 @@
-const fetch = (...args) =>
-  import('node-fetch').then(({ default: fetch }) => fetch(...args));
+const fetchFn =
+  global.fetch || ((...a) => import('node-fetch').then(m => m.default(...a)));
+
+const USER_AGENT =
+  process.env.EA_USER_AGENT || 'UPCL/1.0 (https://your-domain.example)';
 
 async function fetchClubLeagueMatches(clubIds) {
   const ids = Array.isArray(clubIds) ? clubIds : [clubIds];
@@ -10,9 +13,9 @@ async function fetchClubLeagueMatches(clubIds) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 10000);
   try {
-    const res = await fetch(url, {
+    const res = await fetchFn(url, {
       headers: {
-        'User-Agent': 'fc-26-project-beta',
+        'User-Agent': USER_AGENT,
         Accept: 'application/json'
       },
       signal: controller.signal
@@ -44,9 +47,9 @@ async function fetchClubMembers(clubId) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 10000);
   try {
-    const res = await fetch(url, {
+    const res = await fetchFn(url, {
       headers: {
-        'User-Agent': 'fc-26-project-beta',
+        'User-Agent': USER_AGENT,
         Accept: 'application/json'
       },
       signal: controller.signal
@@ -75,9 +78,9 @@ async function fetchPlayersForClub(clubId) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 10000);
   try {
-    const res = await fetch(url, {
+    const res = await fetchFn(url, {
       headers: {
-        'User-Agent': 'fc-26-project-beta',
+        'User-Agent': USER_AGENT,
         Accept: 'application/json'
       },
       signal: controller.signal

--- a/test/eaMembers.test.js
+++ b/test/eaMembers.test.js
@@ -1,0 +1,62 @@
+const { test, mock } = require('node:test');
+const assert = require('assert');
+
+process.env.FIREBASE_SERVICE_ACCOUNT = JSON.stringify({
+  project_id: 'test',
+  client_email: 'test@test',
+  private_key: 'key'
+});
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+
+function firestore() { return {}; }
+firestore.FieldValue = {};
+firestore.FieldPath = {};
+
+const Module = require('module');
+const originalRequire = Module.prototype.require;
+Module.prototype.require = function (id) {
+  if (id === 'firebase-admin') {
+    return {
+      credential: { cert: svc => svc },
+      initializeApp: () => {},
+      apps: [],
+      app: () => ({ options: { projectId: 'test' } }),
+      firestore
+    };
+  }
+  return originalRequire.apply(this, arguments);
+};
+
+const eaApi = require('../services/eaApi');
+const app = require('../server');
+Module.prototype.require = originalRequire;
+
+async function withServer(fn) {
+  const server = app.listen(0);
+  try {
+    const port = server.address().port;
+    await fn(port);
+  } finally {
+    server.close();
+  }
+}
+
+test('normalizes array response', async () => {
+  const stub = mock.method(eaApi, 'fetchClubMembers', async () => [{ name: 'A' }]);
+  await withServer(async port => {
+    const res = await fetch(`http://localhost:${port}/api/ea/clubs/123/members`);
+    const body = await res.json();
+    assert.deepStrictEqual(body, { members: [{ name: 'A' }] });
+  });
+  stub.mock.restore();
+});
+
+test('normalizes object map response', async () => {
+  const stub = mock.method(eaApi, 'fetchClubMembers', async () => ({ members: { a:{ name:'A'}, b:{ name:'B'} } }));
+  await withServer(async port => {
+    const res = await fetch(`http://localhost:${port}/api/ea/clubs/123/members`);
+    const body = await res.json();
+    assert.deepStrictEqual(body, { members: [{ name: 'A' }, { name: 'B' }] });
+  });
+  stub.mock.restore();
+});


### PR DESCRIPTION
## Summary
- normalize `/api/ea/clubs/:clubId/members` responses to always return `{ members: [...] }`
- harden client squad loader to handle varying EA shapes and skip manual teams
- refactor EA API service to reuse global fetch and send a descriptive User-Agent
- add tests covering member normalization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5177020f0832e87bddd634028e6f6