### PR TITLE
fix: expose EA club members route and improve squad errors

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -624,13 +624,20 @@ async function resolvePlayerName(id){
 
 async function fetchClubMembers(clubId){
   if (!/^\d+$/.test(String(clubId))) return { members: [] };
-  const raw = await apiGet(`/api/ea/clubs/${encodeURIComponent(clubId)}/members`);
-  if (Array.isArray(raw)) return { members: raw };
-  if (Array.isArray(raw?.members)) return raw;
-  if (raw?.members && typeof raw.members === 'object') {
-    return { members: Object.values(raw.members) };
+  try{
+    const raw = await apiGet(`/api/ea/clubs/${encodeURIComponent(clubId)}/members`);
+    if (Array.isArray(raw)) return { members: raw };
+    if (Array.isArray(raw?.members)) return raw;
+    if (raw?.members && typeof raw.members === 'object') {
+      return { members: Object.values(raw.members) };
+    }
+    return { members: [] };
+  }catch(e){
+    const m = String(e.message||'');
+    const match = /^HTTP (\d+)/.exec(m);
+    const status = match ? Number(match[1]) : e.status;
+    throw Object.assign(new Error(m), { status });
   }
-  return { members: [] };
 }
 
 // nav elements
@@ -840,7 +847,13 @@ async function loadSquad(clubId){
       return `<div class="m-card" style="margin:6px 0">${escapeHtml(n)}</div>`;
     }).join('');
   }catch(e){
-    body.textContent = 'Failed to load squad.';
+    if (e.status === 504) {
+      body.textContent = 'EA API timed out. Try again.';
+    } else if (e.status === 502) {
+      body.textContent = 'EA API request failed.';
+    } else {
+      body.textContent = 'Failed to load squad.';
+    }
   }
 }
 

--- a/test/eaMembers.test.js
+++ b/test/eaMembers.test.js
@@ -42,7 +42,7 @@ async function withServer(fn) {
 }
 
 test('normalizes array response', async () => {
-  const stub = mock.method(eaApi, 'fetchClubMembers', async () => [{ name: 'A' }]);
+  const stub = mock.method(eaApi, 'fetchPlayersForClub', async () => [{ name: 'A' }]);
   await withServer(async port => {
     const res = await fetch(`http://localhost:${port}/api/ea/clubs/123/members`);
     const body = await res.json();
@@ -52,7 +52,7 @@ test('normalizes array response', async () => {
 });
 
 test('normalizes object map response', async () => {
-  const stub = mock.method(eaApi, 'fetchClubMembers', async () => ({ members: { a:{ name:'A'}, b:{ name:'B'} } }));
+  const stub = mock.method(eaApi, 'fetchPlayersForClub', async () => ({ members: { a:{ name:'A'}, b:{ name:'B'} } }));
   await withServer(async port => {
     const res = await fetch(`http://localhost:${port}/api/ea/clubs/123/members`);
     const body = await res.json();


### PR DESCRIPTION
## Summary
- add `/api/ea/clubs/:clubId/members` server route backed by `fetchPlayersForClub`
- clarify squad panel errors for 502/504 and propagate HTTP status from `fetchClubMembers`
- adjust unit tests for new EA route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a51e2d5e78832eb7c651ace3a18336