### PR TITLE
Harden player aggregation with sequential EA fetch

### DIFF
--- a/data/teams.json
+++ b/data/teams.json
@@ -22,6 +22,4 @@
   { "id": "fc-dhizz",      "name": "FC Dhizz",      "logo": "/assets/logos/fc-dhizz.png" },
 
   { "id": "elite-xi",      "name": "Elite xi",      "logo": "/assets/logos/elite-xi.png" }
-=======
-  { "id": "Elite-xi",      "name": "Elite xi",      "logo": "/assets/logos/elite-xi.png" }
 ]


### PR DESCRIPTION
## Summary
- Add browser-like headers and logging when fetching club players
- Sequentially fetch league players with delay to avoid EA blocking
- Fix malformed `data/teams.json`

## Testing
- `npm test` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a86ec10c832e9241d03cf38f3312