### PR TITLE
Fix HTML structure and initialization errors

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -1,18 +1,27 @@
-<!doctype html><meta charset="utf-8">
-<title>Chat</title>
-<style>body{font:14px Arial;margin:0;background:#000;color:#fff}header{padding:12px;background:#111}
-main{padding:12px;max-width:800px;margin:auto}#log{height:60vh;overflow:auto;border:1px solid #333;padding:8px;background:#0b0b0b}
-input,button{padding:10px;border-radius:8px;border:1px solid #333;background:#1a1a1a;color:#fff}
-button{cursor:pointer}</style>
-<header><h3 id="title">Chat</h3></header>
-<main>
-  <div id="log"></div>
-  <div style="display:flex;gap:8px;margin-top:8px">
-    <input id="msg" placeholder="Type a message…" style="flex:1">
-    <button id="send">Send</button>
-  </div>
-</main>
-<script>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Chat</title>
+  <style>
+    body{font:14px Arial;margin:0;background:#000;color:#fff}
+    header{padding:12px;background:#111}
+    main{padding:12px;max-width:800px;margin:auto}
+    #log{height:60vh;overflow:auto;border:1px solid #333;padding:8px;background:#0b0b0b}
+    input,button{padding:10px;border-radius:8px;border:1px solid #333;background:#1a1a1a;color:#fff}
+    button{cursor:pointer}
+  </style>
+</head>
+<body>
+  <header><h3 id="title">Chat</h3></header>
+  <main>
+    <div id="log"></div>
+    <div style="display:flex;gap:8px;margin-top:8px">
+      <input id="msg" placeholder="Type a message…" style="flex:1">
+      <button id="send">Send</button>
+    </div>
+  </main>
+  <script>
 const params = new URLSearchParams(location.search);
 const room = params.get('room') || 'lobby';
 document.getElementById('title').textContent = `Chat — ${room}`;
@@ -29,4 +38,7 @@ document.getElementById('send').onclick = ()=>{
   save(text); add({t:Date.now(), text}); msg.value='';
 };
 load();
-</script>
+  </script>
+</body>
+</html>
+

--- a/public/teams.html
+++ b/public/teams.html
@@ -176,7 +176,7 @@ h2{margin:0 0 10px}
 <body>
 <div id="intro">
     <img src="/assets/logos/UPCL.png" alt="League logo">
-  <audio id="introAudio" src="/assets/intro.mp3"></audio>
+  <audio id="introAudio" src="/intro.mp3"></audio>
 </div>
 <header>
   <h1>Pro Club — League Hub</h1>
@@ -562,9 +562,6 @@ async function loadTeams(){
     teams = [];
     teamsGrid.innerHTML = '<div class="muted">Failed to load teams</div>';
     return false;
-  }catch{
-    teams = [];
-
   }
 }
 
@@ -584,7 +581,10 @@ function replaceClubIds(str){
   });
 }
 function teamLogoUrl(team){ return team?.logo || `https://via.placeholder.com/800x480.png?text=${encodeURIComponent(team?.name||'Club')}`; }
-function escapeHtml(s){ return String(s).replace(/[&<>"']/g, c=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c])); }
+function escapeHtml(s){
+  const map = { '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' };
+  return String(s).replace(/[&<>"']/g, c => map[c]);
+}
 function fmtMoney(n){ return '₵' + Number(n||0).toLocaleString(); }
 function fmtDate(ms){ try{ return new Date(ms).toLocaleString(); } catch{ return ''; } }
 function getFixtureBanner(){ return '/assets/ui/fixture-banner.png'; }
@@ -1813,10 +1813,6 @@ async function init(){
   const playerLoad = loadPlayers().catch(e => console.error('Failed to load players', e));
   const ok = await loadTeams();
   if (ok) renderTeams();
-
-  await loadTeams();
-  await loadPlayers();
-  renderTeams();
   await checkAdmin();
   await checkMe();
 


### PR DESCRIPTION
## Summary
- remove stray catch in team loader and sanitize HTML escape map
- repair intro audio path and streamline init routines
- wrap chat page in proper HTML skeleton

## Testing
- `npm test` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68a5aaacd9d0832eb26793fb3c74ebdc