### PR TITLE
Add default Postgres connection string fallback

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,12 +1,12 @@
 const { Pool } = require('pg');
 
-if (!process.env.DATABASE_URL) {
-  throw new Error('DATABASE_URL env var is required');
-}
-
 const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
+  connectionString:
+    process.env.DATABASE_URL ||
+    "postgresql://upcl_user:2wMTWrulMhUoAYk5Z9lUpgaYYZobJYGf@dpg-d2hslce3jp1c738nvgg0-a:5432/upcl?sslmode=require",
+  ssl: {
+    rejectUnauthorized: false,
+  },
 });
 
 // Ensure fixtures table exists


### PR DESCRIPTION
## Summary
- allow database connections without explicit DATABASE_URL by providing a default connection string

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6490b9ac0832eb911d6b5fbb35426