### PR TITLE
Add teams API route with proper error handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -108,6 +108,19 @@ app.get('/api/ea/clubs/:clubId/members', async (req, res) => {
   }
 });
 
+// Basic teams listing
+app.get('/api/teams', async (_req, res) => {
+  try {
+    const { rows } = await pool.query(
+      'SELECT * FROM teams ORDER BY updated_at DESC LIMIT 20'
+    );
+    res.json({ ok: true, teams: rows });
+  } catch (err) {
+    console.error('Failed to load teams:', err);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
 // Cached teams with players
 app.get('/api/teams-with-players', async (_req, res) => {
   try {

--- a/test/teams.test.js
+++ b/test/teams.test.js
@@ -1,0 +1,41 @@
+const { test, mock } = require('node:test');
+const assert = require('assert');
+
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+
+const pool = require('../db');
+
+async function withServer(fn) {
+  const app = require('../server');
+  const server = app.listen(0);
+  try {
+    const port = server.address().port;
+    await fn(port);
+  } finally {
+    server.close();
+  }
+}
+
+test('returns teams from database', async () => {
+  const stub = mock.method(pool, 'query', async () => ({ rows: [{ id: 1 }] }));
+  await withServer(async port => {
+    const res = await fetch(`http://localhost:${port}/api/teams`);
+    const body = await res.json();
+    assert.deepStrictEqual(body, { ok: true, teams: [{ id: 1 }] });
+  });
+  stub.mock.restore();
+});
+
+test('handles database errors gracefully', async () => {
+  const stub = mock.method(pool, 'query', async () => {
+    throw new Error('boom');
+  });
+  await withServer(async port => {
+    const res = await fetch(`http://localhost:${port}/api/teams`);
+    assert.strictEqual(res.status, 500);
+    const body = await res.json();
+    assert.deepStrictEqual(body, { ok: false, error: 'boom' });
+  });
+  stub.mock.restore();
+});
+


### PR DESCRIPTION
## Summary
- add `/api/teams` endpoint querying Postgres via `pg.Pool`
- return structured JSON and catch query errors
- test success and error scenarios for `/api/teams`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6525ba314832e88f77b0af11f915a