### PR TITLE
feat: load players from cached API

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -205,7 +205,118 @@ h2{margin:0 0 10px}
       <h2 style="margin:0">Teams</h2>
       <div class="muted">Total teams: <span id="teams-count">0</span></div>
     </div>
-    <div class="teams-grid" id="teamsGrid" role="list"></div>
+    <div class="teams-grid" id="teamsGrid" role="list">
+      <div class="team-card" data-club-id="2491998" role="listitem">
+        <img class="team-logo" src="/assets/logos/royal-republic-logo.png" alt="Royal Republic logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Royal%20Republic';" />
+        <div class="team-meta"><div class="name">Royal Republic</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="1527486" role="listitem">
+        <img class="team-logo" src="/assets/logos/gungan-fc.png" alt="Gungan FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Gungan%20FC';" />
+        <div class="team-meta"><div class="name">Gungan FC</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="1969494" role="listitem">
+        <img class="team-logo" src="/assets/logos/club-frijol.png" alt="Club Frijol logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Club%20Frijol';" />
+        <div class="team-meta"><div class="name">Club Frijol</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="2086022" role="listitem">
+        <img class="team-logo" src="/assets/logos/brehemen.png" alt="Brehemen logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Brehemen';" />
+        <div class="team-meta"><div class="name">Brehemen</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="2462194" role="listitem">
+        <img class="team-logo" src="/assets/logos/costa-chica-fc.png" alt="Costa Chica FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Costa%20Chica%20FC';" />
+        <div class="team-meta"><div class="name">Costa Chica FC</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="5098824" role="listitem">
+        <img class="team-logo" src="/assets/logos/sporting-de-la-ma.png" alt="Sporting de la ma logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Sporting%20de%20la%20ma';" />
+        <div class="team-meta"><div class="name">Sporting de la ma</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="4869810" role="listitem">
+        <img class="team-logo" src="/assets/logos/afc-tekki.png" alt="Afc Tekki logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Afc%20Tekki';" />
+        <div class="team-meta"><div class="name">Afc Tekki</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="576007" role="listitem">
+        <img class="team-logo" src="/assets/logos/ethabella-fc.png" alt="Ethabella FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Ethabella%20FC';" />
+        <div class="team-meta"><div class="name">Ethabella FC</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="4933507" role="listitem">
+        <img class="team-logo" src="/assets/logos/loss-toyz.png" alt="Loss Toyz logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Loss%20Toyz';" />
+        <div class="team-meta"><div class="name">Loss Toyz</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="4824736" role="listitem">
+        <img class="team-logo" src="/assets/logos/goldengoals-fc.png" alt="GoldenGoals FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=GoldenGoals%20FC';" />
+        <div class="team-meta"><div class="name">GoldenGoals FC</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="481847" role="listitem">
+        <img class="team-logo" src="/assets/logos/rooney-tunes.png" alt="Rooney tunes logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Rooney%20tunes';" />
+        <div class="team-meta"><div class="name">Rooney tunes</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="3050467" role="listitem">
+        <img class="team-logo" src="/assets/logos/invincible-afc.png" alt="invincible afc logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=invincible%20afc';" />
+        <div class="team-meta"><div class="name">invincible afc</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="4154835" role="listitem">
+        <img class="team-logo" src="/assets/logos/khalch-fc.png" alt="khalch Fc logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=khalch%20Fc';" />
+        <div class="team-meta"><div class="name">khalch Fc</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="3638105" role="listitem">
+        <img class="team-logo" src="/assets/logos/real-mvc.png" alt="Real mvc logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Real%20mvc';" />
+        <div class="team-meta"><div class="name">Real mvc</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="55408" role="listitem">
+        <img class="team-logo" src="/assets/logos/elite-vt.png" alt="Elite VT logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Elite%20VT';" />
+        <div class="team-meta"><div class="name">Elite VT</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="4819681" role="listitem">
+        <img class="team-logo" src="/assets/logos/everything-dead.png" alt="EVERYTHING DEAD logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=EVERYTHING%20DEAD';" />
+        <div class="team-meta"><div class="name">EVERYTHING DEAD</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="35642" role="listitem">
+        <img class="team-logo" src="/assets/logos/ebk-fc.png" alt="EBK FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=EBK%20FC';" />
+        <div class="team-meta"><div class="name">EBK FC</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="afc-warriors" role="listitem">
+        <img class="team-logo" src="/assets/logos/afc-warriors.png" alt="AFC Warriors logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=AFC%20Warriors';" />
+        <div class="team-meta"><div class="name">AFC Warriors</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="jids-trivela" role="listitem">
+        <img class="team-logo" src="/assets/logos/jids-trivela.png" alt="Jids Trivela logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Jids%20Trivela';" />
+        <div class="team-meta"><div class="name">Jids Trivela</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="razorblack-fc" role="listitem">
+        <img class="team-logo" src="/assets/logos/razorblack-fc.png" alt="Razorblack FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Razorblack%20FC';" />
+        <div class="team-meta"><div class="name">Razorblack FC</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="fc-dhizz" role="listitem">
+        <img class="team-logo" src="/assets/logos/fc-dhizz.png" alt="FC Dhizz logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=FC%20Dhizz';" />
+        <div class="team-meta"><div class="name">FC Dhizz</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+      <div class="team-card" data-club-id="elite-xi" role="listitem">
+        <img class="team-logo" src="/assets/logos/elite-xi.png" alt="Elite xi logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Elite%20xi';" />
+        <div class="team-meta"><div class="name">Elite xi</div><div class="record"></div></div>
+        <div class="player-list"></div>
+      </div>
+    </div>
   </section>
 
   <!-- NEWS -->
@@ -546,47 +657,19 @@ const CC_ID = 'UPCL_CC_2025_08'; // current Champions Cup id
 const LEAGUE_ID = 'UPCL_LEAGUE_2025'; // current League id
 const FRIENDLIES_ID = 'UPCL_FRIENDLIES_2025'; // current Friendlies id
 
-const CLUB_IDS = [
-  2491998, 1527486, 1969494, 2086022, 2462194, 5098824, 4869810, 576007,
-  4933507, 4824736, 481847, 3050467, 4154835, 3638105, 55408, 4819681,
-  35642
-];
-
-// Teams (add FC Dhizz)
+// Teams
 let teams = [];
-async function loadTeams(){
-  try{
-    teams = [];
-    playersByClub = {};
-    for (const id of CLUB_IDS){
-      const info = await apiGet(`/api/ea/clubs/${id}/info`).catch(()=>({}));
-      const mem = await apiGet(`/api/ea/clubs/${id}/members`).catch(()=>({}));
-      const club = info.club || {};
-      const raw = Array.isArray(mem.members) ? mem.members : [];
-      const players = raw.map(p => ({
-        name: p.name || p.playername || p.personaName || '',
-        position: p.position || p.preferredPosition || '',
-        stats: p
-      }));
-      const team = {
-        id: Number(id),
-        name: club.name || `Club ${id}`,
-        logo: club.customLogo,
-        season: club.season,
-        players
-      };
-      teams.push(team);
-      playersByClub[id] = players;
-      await new Promise(r => setTimeout(r, 1000));
-    }
-    return true;
-  }catch(e){
-    console.error('Failed to load teams', e);
-    teams = [];
-    playersByClub = {};
-    teamsGrid.innerHTML = '<div class="muted">Failed to load teams</div>';
-    return false;
-  }
+
+function buildStaticTeams(){
+  teams = Array.from(document.querySelectorAll('.team-card')).map(card => {
+    const id = card.getAttribute('data-club-id');
+    const name = card.querySelector('.name').textContent.trim();
+    const logo = card.querySelector('.team-logo').getAttribute('src');
+    const team = { id, name, logo };
+    card.addEventListener('click', () => showTeam(team));
+    return team;
+  });
+  document.getElementById('teams-count').textContent = teams.length;
 }
 
 // helpers
@@ -635,27 +718,16 @@ const playerNameCache = new Map();
 async function resolvePlayerName(id){
   if(!id) return '';
   if(playerNameCache.has(id)) return playerNameCache.get(id);
-  try{
-    const d = await apiGet(`/api/players/${encodeURIComponent(id)}`);
-    const name = d.player?.eaName || d.player?.name || '';
-    playerNameCache.set(id, name || id);
-    return name || id;
-  }catch{
-    playerNameCache.set(id, id);
-    return id;
+  for (const arr of Object.values(playersByClub)) {
+    const p = arr.find(m => String(m.personaId||m.playerId||m.id) === String(id));
+    if (p) {
+      const name = p.name || p.playername || p.personaName || '';
+      playerNameCache.set(id, name || id);
+      return name || id;
+    }
   }
-}
-
-const membersCache = new Map();
-async function fetchClubMembers(clubId){
-  const c = membersCache.get(clubId) || (playersByClub[clubId] ? { at: 0, data: playersByClub[clubId] } : null);
-  if (c && Date.now() - c.at < 60_000){
-    return { members: c.data };
-  }
-  const d = await apiGet(`/api/ea/clubs/${encodeURIComponent(clubId)}/members`).catch(()=>({}));
-  const members = Array.isArray(d.members) ? d.members : [];
-  membersCache.set(clubId, { at: Date.now(), data: members });
-  return { members };
+  playerNameCache.set(id, id);
+  return id;
 }
 
 // nav elements
@@ -769,33 +841,22 @@ const detailTitle = document.getElementById('detail-title');
 const detailSub   = document.getElementById('detail-sub');
 const backBtn = document.getElementById('backBtn');
 
-function renderTeams(){
-  teamsGrid.innerHTML='';
-  teamsCount.textContent = teams.length;
-  teams.forEach(team=>{
-    const card = document.createElement('div');
-    card.className='team-card';
-    card.setAttribute('role','listitem');
-    const record = team.season ? `${team.season.wins||0}-${team.season.ties||0}-${team.season.losses||0}` : '';
-    const playersHtml = (team.players||[]).map(p=>{
-      const n = p.name || p.playername || p.personaName || '';
-      const pos = p.position || p.preferredPosition || '';
-      return `<div class="player-row"><span>${escapeHtml(n)}</span><span class="muted">${escapeHtml(pos)}</span></div>`;
-    }).join('');
-    card.innerHTML = `
-      <img class="team-logo"
-           src="${teamLogoUrl(team)}"
-           onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=${encodeURIComponent(team.name)}';"
-           alt="${escapeHtml(team.name)} logo" />
-      <div class="team-meta">
-        <div class="name">${escapeHtml(team.name)}</div>
-        <div class="record">${record}</div>
-      </div>
-      <div class="player-list">${playersHtml}</div>
-    `;
-    card.addEventListener('click', ()=> showTeam(team));
-    teamsGrid.appendChild(card);
-  });
+async function loadPlayers(){
+  try{
+    const d = await apiGet('/api/players');
+    playersByClub = d.byClub || {};
+    for (const team of teams) {
+      const listEl = document.querySelector(`.team-card[data-club-id="${team.id}"] .player-list`);
+      const members = playersByClub[team.id] || [];
+      listEl.innerHTML = members.map(p=>{
+        const n = p.name || p.playername || p.personaName || '';
+        const pos = p.position || p.preferredPosition || '';
+        return `<div class="player-row"><span>${escapeHtml(n)}</span><span class="muted">${escapeHtml(pos)}</span></div>`;
+      }).join('');
+    }
+  }catch(e){
+    console.error('Failed to load players', e);
+  }
 }
 
 async function showTeam(team){
@@ -856,11 +917,12 @@ async function loadSquad(clubId){
   body.textContent = 'Loading…';
   document.getElementById('squadTools').style.display = 'none';
   try{
-    let members = [];
-    if (/^\d+$/.test(String(clubId))){
-      const { members: eaMembers } = await fetchClubMembers(clubId);
-      members = eaMembers || [];
-    } else {
+    let members = playersByClub[clubId] || [];
+    if (!members.length && /^\d+$/.test(String(clubId))){
+      const d = await apiGet(`/api/players?clubId=${encodeURIComponent(clubId)}`).catch(()=>({}));
+      members = (d.byClub && d.byClub[clubId]) || [];
+      playersByClub[clubId] = members;
+    } else if (!members.length){
       const r = await fetch(`/api/clubs/${encodeURIComponent(clubId)}/squad`, {credentials:'include'})
         .then(res => res.ok ? res.json() : { slots: [] })
         .catch(() => ({ slots: [] }));
@@ -1839,8 +1901,8 @@ async function computeNewsFromFixtures(list){
 // =======================
 async function init(){
 
-  const ok = await loadTeams();
-  if (ok) renderTeams();
+  buildStaticTeams();
+  await loadPlayers();
   await checkAdmin();
   await checkMe();
 


### PR DESCRIPTION
## Summary
- Render static team cards in HTML
- Fetch player lists once from `/api/players` and inject into cards
- Remove direct frontend use of EA club members endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a668a3a520832e8ed3a898c6db3214