### PR TITLE
Render players only within team cards

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -71,9 +71,9 @@ h2{margin:0 0 10px}
 .team-meta{width:100%;display:flex;align-items:center;justify-content:space-between;margin-top:10px;gap:8px}
 .team-meta .name{font-weight:800;font-size:17px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .team-meta .record{font-weight:700;font-size:14px}
-.player-list{margin-top:10px;display:flex;flex-direction:column;gap:4px;font-size:14px}
-.player-row{display:flex;justify-content:space-between;border-bottom:1px solid #220000;padding:2px 0}
-.player-row:last-child{border-bottom:0}
+.player-list{margin-top:10px;display:flex;flex-direction:column;gap:4px;font-size:14px;list-style:none;padding:0}
+.player-list li{display:flex;justify-content:space-between;border-bottom:1px solid #220000;padding:2px 0}
+.player-list li:last-child{border-bottom:0}
 
 /* Generic card */
 .m-card{background:#110000;border:1px solid #2a0000;border-radius:12px;box-shadow:0 6px 18px rgba(255,0,0,.15);padding:12px}
@@ -209,112 +209,90 @@ h2{margin:0 0 10px}
       <div class="team-card" data-club-id="2491998" role="listitem">
         <img class="team-logo" src="/assets/logos/royal-republic-logo.png" alt="Royal Republic logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Royal%20Republic';" />
         <div class="team-meta"><div class="name">Royal Republic</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="1527486" role="listitem">
         <img class="team-logo" src="/assets/logos/gungan-fc.png" alt="Gungan FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Gungan%20FC';" />
         <div class="team-meta"><div class="name">Gungan FC</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="1969494" role="listitem">
         <img class="team-logo" src="/assets/logos/club-frijol.png" alt="Club Frijol logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Club%20Frijol';" />
         <div class="team-meta"><div class="name">Club Frijol</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="2086022" role="listitem">
         <img class="team-logo" src="/assets/logos/brehemen.png" alt="Brehemen logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Brehemen';" />
         <div class="team-meta"><div class="name">Brehemen</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="2462194" role="listitem">
         <img class="team-logo" src="/assets/logos/costa-chica-fc.png" alt="Costa Chica FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Costa%20Chica%20FC';" />
         <div class="team-meta"><div class="name">Costa Chica FC</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="5098824" role="listitem">
         <img class="team-logo" src="/assets/logos/sporting-de-la-ma.png" alt="Sporting de la ma logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Sporting%20de%20la%20ma';" />
         <div class="team-meta"><div class="name">Sporting de la ma</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="4869810" role="listitem">
         <img class="team-logo" src="/assets/logos/afc-tekki.png" alt="Afc Tekki logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Afc%20Tekki';" />
         <div class="team-meta"><div class="name">Afc Tekki</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="576007" role="listitem">
         <img class="team-logo" src="/assets/logos/ethabella-fc.png" alt="Ethabella FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Ethabella%20FC';" />
         <div class="team-meta"><div class="name">Ethabella FC</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="4933507" role="listitem">
         <img class="team-logo" src="/assets/logos/loss-toyz.png" alt="Loss Toyz logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Loss%20Toyz';" />
         <div class="team-meta"><div class="name">Loss Toyz</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="4824736" role="listitem">
         <img class="team-logo" src="/assets/logos/goldengoals-fc.png" alt="GoldenGoals FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=GoldenGoals%20FC';" />
         <div class="team-meta"><div class="name">GoldenGoals FC</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="481847" role="listitem">
         <img class="team-logo" src="/assets/logos/rooney-tunes.png" alt="Rooney tunes logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Rooney%20tunes';" />
         <div class="team-meta"><div class="name">Rooney tunes</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="3050467" role="listitem">
         <img class="team-logo" src="/assets/logos/invincible-afc.png" alt="invincible afc logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=invincible%20afc';" />
         <div class="team-meta"><div class="name">invincible afc</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="4154835" role="listitem">
         <img class="team-logo" src="/assets/logos/khalch-fc.png" alt="khalch Fc logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=khalch%20Fc';" />
         <div class="team-meta"><div class="name">khalch Fc</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="3638105" role="listitem">
         <img class="team-logo" src="/assets/logos/real-mvc.png" alt="Real mvc logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Real%20mvc';" />
         <div class="team-meta"><div class="name">Real mvc</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="55408" role="listitem">
         <img class="team-logo" src="/assets/logos/elite-vt.png" alt="Elite VT logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Elite%20VT';" />
         <div class="team-meta"><div class="name">Elite VT</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="4819681" role="listitem">
         <img class="team-logo" src="/assets/logos/everything-dead.png" alt="EVERYTHING DEAD logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=EVERYTHING%20DEAD';" />
         <div class="team-meta"><div class="name">EVERYTHING DEAD</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="35642" role="listitem">
         <img class="team-logo" src="/assets/logos/ebk-fc.png" alt="EBK FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=EBK%20FC';" />
         <div class="team-meta"><div class="name">EBK FC</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="afc-warriors" role="listitem">
         <img class="team-logo" src="/assets/logos/afc-warriors.png" alt="AFC Warriors logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=AFC%20Warriors';" />
         <div class="team-meta"><div class="name">AFC Warriors</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="jids-trivela" role="listitem">
         <img class="team-logo" src="/assets/logos/jids-trivela.png" alt="Jids Trivela logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Jids%20Trivela';" />
         <div class="team-meta"><div class="name">Jids Trivela</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="razorblack-fc" role="listitem">
         <img class="team-logo" src="/assets/logos/razorblack-fc.png" alt="Razorblack FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Razorblack%20FC';" />
         <div class="team-meta"><div class="name">Razorblack FC</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="fc-dhizz" role="listitem">
         <img class="team-logo" src="/assets/logos/fc-dhizz.png" alt="FC Dhizz logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=FC%20Dhizz';" />
         <div class="team-meta"><div class="name">FC Dhizz</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
       <div class="team-card" data-club-id="elite-xi" role="listitem">
         <img class="team-logo" src="/assets/logos/elite-xi.png" alt="Elite xi logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Elite%20xi';" />
         <div class="team-meta"><div class="name">Elite xi</div><div class="record"></div></div>
-        <div class="player-list"></div>
       </div>
     </div>
   </section>
@@ -845,15 +823,22 @@ async function loadPlayers(){
   try{
     const d = await apiGet('/api/players');
     playersByClub = d.byClub || {};
-    for (const team of teams) {
-      const listEl = document.querySelector(`.team-card[data-club-id="${team.id}"] .player-list`);
-      const members = playersByClub[team.id] || [];
-      listEl.innerHTML = members.map(p=>{
+    document.querySelectorAll('.team-card').forEach(card => {
+      const clubId = card.getAttribute('data-club-id');
+      const existing = card.querySelector('.player-list');
+      if (existing) existing.remove();
+      const members = playersByClub[clubId] || [];
+      const ul = document.createElement('ul');
+      ul.className = 'player-list';
+      members.forEach(p => {
         const n = p.name || p.playername || p.personaName || '';
         const pos = p.position || p.preferredPosition || '';
-        return `<div class="player-row"><span>${escapeHtml(n)}</span><span class="muted">${escapeHtml(pos)}</span></div>`;
-      }).join('');
-    }
+        const li = document.createElement('li');
+        li.textContent = `${n} — ${pos}`;
+        ul.appendChild(li);
+      });
+      card.appendChild(ul);
+    });
   }catch(e){
     console.error('Failed to load players', e);
   }


### PR DESCRIPTION
## Summary
- Render players directly inside their team cards with new `<ul>` lists
- Remove global/placeholder player list elements and style list items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a66c753e58832e81f61c53085599bf