### PR TITLE
Add scheduled EA league match ingestion and API endpoint

### DIFF
--- a/db.js
+++ b/db.js
@@ -60,10 +60,9 @@ ensureTable(
 ensureTable(
   `
   CREATE TABLE IF NOT EXISTS matches (
-    id BIGINT PRIMARY KEY,
-    timestamp TIMESTAMPTZ,
-    clubs JSONB,
-    players JSONB,
+    id TEXT PRIMARY KEY,
+    matchDate TIMESTAMPTZ,
+    clubIds JSONB,
     raw JSONB
   )
 `,

--- a/services/matches.js
+++ b/services/matches.js
@@ -1,0 +1,36 @@
+const fetchFn =
+  global.fetch || ((...a) => import('node-fetch').then(m => m.default(...a)));
+
+const EA_HEADERS = {
+  'User-Agent': 'Mozilla/5.0',
+  Accept: 'application/json',
+  Referer: 'https://www.ea.com/',
+  Origin: 'https://www.ea.com'
+};
+
+async function fetchLeagueMatches(clubId) {
+  const url = `https://proclubs.ea.com/api/fc/clubs/matches?matchType=leagueMatch&platform=common-gen5&clubIds=${clubId}`;
+  const res = await fetchFn(url, { headers: EA_HEADERS });
+  if (!res.ok) throw new Error(`EA responded ${res.status}`);
+  const data = await res.json();
+  return data?.[clubId] || [];
+}
+
+async function saveLeagueMatches(clubId, pool) {
+  const matches = await fetchLeagueMatches(clubId);
+  for (const m of matches) {
+    await pool.query(
+      `INSERT INTO matches (id, matchDate, clubIds, raw)
+       VALUES ($1, to_timestamp($2 / 1000), $3, $4)
+       ON CONFLICT (id) DO NOTHING`,
+      [
+        String(m.matchId),
+        m.timestamp,
+        JSON.stringify(m.clubIds || []),
+        JSON.stringify(m)
+      ]
+    );
+  }
+}
+
+module.exports = { fetchLeagueMatches, saveLeagueMatches };


### PR DESCRIPTION
## Summary
- create Postgres `matches` table storing match date, clubs and raw payload
- add service to fetch EA league matches and persist them if new
- schedule periodic fetches and expose `/api/leagues/:leagueId/matches` endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6a07eefbc832ea53c010b3d703c0a