### PR TITLE
Add backend matches endpoint and update frontend

### DIFF
--- a/public/fixtures.html
+++ b/public/fixtures.html
@@ -16,15 +16,7 @@
 
   <script>
     async function fetchMatches(clubId) {
-      const url = `https://proclubs.ea.com/api/fc/clubs/matches?matchType=leagueMatch&platform=common-gen5&clubIds=${clubId}`;
-      const res = await fetch(url, {
-        headers: {
-          'User-Agent': navigator.userAgent,
-          Accept: 'application/json',
-          Referer: 'https://www.ea.com/',
-          Connection: 'keep-alive'
-        }
-      });
+      const res = await fetch(`/api/matches?clubId=${clubId}`);
       if (!res.ok) throw new Error('Failed to fetch matches');
       return res.json();
     }
@@ -44,23 +36,13 @@
       });
     }
 
-    async function storeMatches(matches) {
-      await fetch('/api/store-matches', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(matches)
-      });
-    }
-
     document.getElementById('btnFetch').onclick = async () => {
       const clubId = document.getElementById('clubId').value.trim();
       if (!clubId) return;
       try {
-        const data = await fetchMatches(clubId);
-        const matches = data[clubId] || data;
+        const matches = await fetchMatches(clubId);
         console.log(matches);
         renderMatches(matches);
-        await storeMatches(matches);
       } catch (e) {
         console.error(e);
         alert(e.message);

--- a/server.js
+++ b/server.js
@@ -170,6 +170,53 @@ app.get('/api/teams', async (_req, res) => {
   }
 });
 
+// Fetch recent matches from EA and store in Postgres
+app.get('/api/matches', async (req, res) => {
+  // Allow explicit override (?clubIds=1,2,3), otherwise use default league list
+  const q = req.query.clubId || req.query.clubIds || req.query.ids || '';
+  let clubIds = Array.isArray(q)
+    ? q
+    : String(q)
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean);
+  if (!clubIds.length) clubIds = DEFAULT_CLUB_IDS.slice();
+  clubIds = clubIds.filter(isNumericId);
+
+  const allMatches = [];
+
+  for (const id of clubIds) {
+    try {
+      const url =
+        `https://proclubs.ea.com/api/fc/clubs/matches?matchType=leagueMatch&platform=common-gen5&clubIds=${id}`;
+      const resEa = await fetchFn(url, { headers: EA_HEADERS });
+      if (!resEa.ok) throw new Error(`EA responded ${resEa.status}`);
+      const data = await resEa.json();
+      const matches = data?.[id] || [];
+      for (const match of matches) {
+        await pool.query(
+          `INSERT INTO matches (id, "timestamp", clubs, players, raw)
+           VALUES ($1, to_timestamp($2 / 1000), $3, $4, $5)
+           ON CONFLICT (id) DO NOTHING`,
+          [
+            String(match.matchId),
+            match.timestamp,
+            JSON.stringify(match.clubs || {}),
+            JSON.stringify(match.players || {}),
+            JSON.stringify(match)
+          ]
+        );
+      }
+      allMatches.push(...matches);
+    } catch (err) {
+      console.error('Failed fetching matches for club', id, err.message);
+    }
+    await new Promise(r => setTimeout(r, 200));
+  }
+
+  res.json(allMatches);
+});
+
 // Recent matches served from Postgres
 app.get('/api/leagues/:leagueId/matches', async (req, res) => {
   const { leagueId } = req.params;


### PR DESCRIPTION
## Summary
- add /api/matches endpoint that fetches from EA, stores in Postgres, and returns matches
- update fixtures page to use backend route instead of calling EA directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6ac905f94832ebeea5c6f0ebc43fe