### PR TITLE
Add admin login endpoints

### DIFF
--- a/public/fixtures.html
+++ b/public/fixtures.html
@@ -16,15 +16,7 @@
 
   <script>
     async function fetchMatches(clubId) {
-      const url = `https://proclubs.ea.com/api/fc/clubs/matches?matchType=leagueMatch&platform=common-gen5&clubIds=${clubId}`;
-      const res = await fetch(url, {
-        headers: {
-          'User-Agent': navigator.userAgent,
-          Accept: 'application/json',
-          Referer: 'https://www.ea.com/',
-          Connection: 'keep-alive'
-        }
-      });
+      const res = await fetch(`/api/matches?clubId=${clubId}`);
       if (!res.ok) throw new Error('Failed to fetch matches');
       return res.json();
     }
@@ -44,23 +36,13 @@
       });
     }
 
-    async function storeMatches(matches) {
-      await fetch('/api/store-matches', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(matches)
-      });
-    }
-
     document.getElementById('btnFetch').onclick = async () => {
       const clubId = document.getElementById('clubId').value.trim();
       if (!clubId) return;
       try {
-        const data = await fetchMatches(clubId);
-        const matches = data[clubId] || data;
+        const matches = await fetchMatches(clubId);
         console.log(matches);
         renderMatches(matches);
-        await storeMatches(matches);
       } catch (e) {
         console.error(e);
         alert(e.message);

--- a/test/admin.test.js
+++ b/test/admin.test.js
@@ -1,0 +1,56 @@
+const { test } = require('node:test');
+const assert = require('assert');
+
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+process.env.ADMIN_PASSWORD = 'secret';
+process.env.SESSION_SECRET = 'test-secret';
+
+async function withServer(fn) {
+  const app = require('../server');
+  const server = app.listen(0);
+  try {
+    const port = server.address().port;
+    await fn(port);
+  } finally {
+    server.close();
+  }
+}
+
+test('admin login lifecycle', async () => {
+  await withServer(async port => {
+    // not signed in
+    let res = await fetch(`http://localhost:${port}/api/admin/me`);
+    let body = await res.json();
+    assert.deepStrictEqual(body, { admin: false });
+
+    // login
+    res = await fetch(`http://localhost:${port}/api/admin/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ password: 'secret' })
+    });
+    assert.strictEqual(res.status, 200);
+    const cookie = res.headers.get('set-cookie').split(';')[0];
+
+    // verify session
+    res = await fetch(`http://localhost:${port}/api/admin/me`, {
+      headers: { cookie }
+    });
+    body = await res.json();
+    assert.deepStrictEqual(body, { admin: true });
+
+    // logout
+    res = await fetch(`http://localhost:${port}/api/admin/logout`, {
+      method: 'POST',
+      headers: { cookie }
+    });
+    assert.strictEqual(res.status, 200);
+
+    res = await fetch(`http://localhost:${port}/api/admin/me`, {
+      headers: { cookie }
+    });
+    body = await res.json();
+    assert.deepStrictEqual(body, { admin: false });
+  });
+});
+


### PR DESCRIPTION
## Summary
- Enable session middleware in Express
- Add /api/admin login, logout, and status routes
- Cover admin login lifecycle with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6ac905f94832ebeea5c6f0ebc43fe