### PR TITLE
Implement automatic match fetching backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "fc-26-project-beta",
   "private": true,
   "engines": { "node": ">=18" },
-  "scripts": { "start": "node server.js", "test": "node --test" },
+  "scripts": { "start": "node server.js", "test": "NODE_ENV=test node --test" },
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "express": "^4.19.2",
     "express-session": "^1.17.3",
     "uuid": "^9.0.1",
     "pg": "^8.11.0",
-    "node-fetch": "^2.6.9"
+    "node-fetch": "^2.6.9",
+    "node-cron": "^3.0.2"
   }
 }

--- a/public/fixtures.html
+++ b/public/fixtures.html
@@ -10,13 +10,11 @@
 </head>
 <body>
   <h1>Fixtures</h1>
-  <input id="clubId" placeholder="Club ID" />
-  <button id="btnFetch">Fetch Matches</button>
   <div id="fixtures"></div>
 
   <script>
-    async function fetchMatches(clubId) {
-      const res = await fetch(`/api/matches?clubId=${clubId}`);
+    async function fetchMatches() {
+      const res = await fetch('/api/matches');
       if (!res.ok) throw new Error('Failed to fetch matches');
       return res.json();
     }
@@ -36,18 +34,16 @@
       });
     }
 
-    document.getElementById('btnFetch').onclick = async () => {
-      const clubId = document.getElementById('clubId').value.trim();
-      if (!clubId) return;
+    async function load() {
       try {
-        const matches = await fetchMatches(clubId);
-        console.log(matches);
+        const matches = await fetchMatches();
         renderMatches(matches);
       } catch (e) {
         console.error(e);
-        alert(e.message);
       }
-    };
+    }
+
+    window.addEventListener('DOMContentLoaded', load);
   </script>
 </body>
 </html>

--- a/utils/matches.js
+++ b/utils/matches.js
@@ -1,0 +1,49 @@
+const fetchFn =
+  global.fetch || ((...a) => import('node-fetch').then(m => m.default(...a)));
+
+const EA_HEADERS = {
+  'User-Agent':
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36',
+  Accept: 'application/json, text/plain, */*',
+  'Accept-Language': 'en-US,en;q=0.9',
+  Referer: 'https://www.ea.com/',
+  Origin: 'https://www.ea.com',
+  Connection: 'keep-alive',
+};
+
+async function fetchMatchesForClub(clubId) {
+  const url = `https://proclubs.ea.com/api/fc/clubs/matches?matchType=leagueMatch&platform=common-gen5&clubIds=${clubId}`;
+  const res = await fetchFn(url, { headers: EA_HEADERS });
+  if (!res.ok) throw new Error(`EA responded ${res.status}`);
+  const data = await res.json();
+  return data?.[clubId] || [];
+}
+
+async function fetchAndStoreMatches(clubIds = [], pool, delayMs = 300) {
+  for (const id of clubIds) {
+    try {
+      const matches = await fetchMatchesForClub(id);
+      for (const m of matches) {
+        await pool.query(
+          `INSERT INTO matches (id, "timestamp", clubs, players, raw)
+           VALUES ($1, to_timestamp($2 / 1000), $3, $4, $5)
+           ON CONFLICT (id) DO NOTHING`,
+          [
+            String(m.matchId),
+            m.timestamp,
+            JSON.stringify(m.clubs || {}),
+            JSON.stringify(m.players || {}),
+            JSON.stringify(m),
+          ]
+        );
+      }
+    } catch (err) {
+      console.error('Failed to fetch/store matches for club', id, err.message || err);
+    }
+    if (delayMs) {
+      await new Promise(r => setTimeout(r, delayMs));
+    }
+  }
+}
+
+module.exports = { fetchAndStoreMatches };


### PR DESCRIPTION
## Summary
- fetch and store EA league matches on startup and every 15 minutes
- serve stored matches from /api/matches and auto-load them on fixtures page
- add match fetching utility and node-cron dependency

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b2a82628832eb89c1eab88e24714