### PR TITLE
Fetch matches in browser and store via API

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fc-26-project-beta",
   "private": true,
   "engines": { "node": ">=18" },
-  "scripts": { "start": "node server.js", "test": "node --test" },
+  "scripts": { "start": "node server.js", "test": "NODE_ENV=test node --test" },
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "express": "^4.19.2",

--- a/public/fixtures.html
+++ b/public/fixtures.html
@@ -10,44 +10,84 @@
 </head>
 <body>
   <h1>Fixtures</h1>
-  <input id="clubId" placeholder="Club ID" />
-  <button id="btnFetch">Fetch Matches</button>
   <div id="fixtures"></div>
 
   <script>
-    async function fetchMatches(clubId) {
-      const res = await fetch(`/api/matches?clubId=${clubId}`);
-      if (!res.ok) throw new Error('Failed to fetch matches');
-      return res.json();
+    const EA_HEADERS = {
+      "User-Agent": "Mozilla/5.0",
+      "Accept": "application/json",
+      "Referer": "https://www.ea.com/",
+      "Connection": "keep-alive"
+    };
+
+    async function getClubIds() {
+      try {
+        const res = await fetch('/api/teams');
+        if (!res.ok) throw new Error('failed');
+        const data = await res.json();
+        return (data.teams || []).map(t => t.id).filter(Boolean);
+      } catch (err) {
+        console.error('Failed to load club ids', err);
+        return [];
+      }
+    }
+
+    async function fetchClubMatches(id) {
+      const url = `https://proclubs.ea.com/api/fc/clubs/matches?matchType=leagueMatch&platform=common-gen5&clubIds=${id}`;
+      const res = await fetch(url, { headers: EA_HEADERS });
+      if (!res.ok) throw new Error('EA request failed');
+      const data = await res.json();
+      return data[id] || [];
     }
 
     function renderMatches(matches) {
       const container = document.getElementById('fixtures');
       container.innerHTML = '';
-      matches.forEach(match => {
-        const card = document.createElement('div');
-        card.className = 'match-card';
-        card.innerHTML = `
-          <h3>Match ${match.matchId}</h3>
-          <p>Date: ${new Date(match.timestamp).toLocaleString()}</p>
-          <p>${match.clubs.home.name} ${match.clubs.home.score} - ${match.clubs.away.score} ${match.clubs.away.name}</p>
-        `;
-        container.appendChild(card);
-      });
+      matches
+        .sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0))
+        .forEach(match => {
+          const id = match.matchId || match.id;
+          const card = document.createElement('div');
+          card.className = 'match-card';
+          card.innerHTML = `
+            <h3>Match ${id}</h3>
+            <p>Date: ${new Date(match.timestamp).toLocaleString()}</p>
+            <p>${match.clubs?.home?.name} ${match.clubs?.home?.score} - ${match.clubs?.away?.score} ${match.clubs?.away?.name}</p>
+          `;
+          container.appendChild(card);
+        });
     }
 
-    document.getElementById('btnFetch').onclick = async () => {
-      const clubId = document.getElementById('clubId').value.trim();
-      if (!clubId) return;
-      try {
-        const matches = await fetchMatches(clubId);
-        console.log(matches);
-        renderMatches(matches);
-      } catch (e) {
-        console.error(e);
-        alert(e.message);
+    async function loadMatches() {
+      const clubIds = await getClubIds();
+      const all = [];
+      for (const id of clubIds) {
+        try {
+          const m = await fetchClubMatches(id);
+          all.push(...m);
+        } catch (err) {
+          console.error('Failed to fetch matches for', id, err);
+        }
+        await new Promise(r => setTimeout(r, 1500));
       }
-    };
+
+      renderMatches(all);
+
+      try {
+        await fetch('/api/saveMatches', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(all)
+        });
+      } catch (err) {
+        console.error('Failed to store matches', err);
+      }
+    }
+
+    window.addEventListener('DOMContentLoaded', () => {
+      loadMatches();
+      setInterval(loadMatches, 15 * 60 * 1000);
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove server-side match fetching and cron jobs
- Add `/api/saveMatches` endpoint to persist posted matches
- Fetch Pro Clubs data from the browser and push to backend for storage

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6b2a82628832eb89c1eab88e24714