### PR TITLE
Fix fixtures fetch and alias match IDs

### DIFF
--- a/public/fixtures.html
+++ b/public/fixtures.html
@@ -39,6 +39,7 @@
       if (!res.ok) throw new Error('EA request failed');
       const data = await res.json();
       return data[id] || [];
+    }
 
     async function fetchMatches() {
       const res = await fetch('/api/matches');
@@ -101,8 +102,9 @@
       try {
         const matches = await fetchMatches();
         renderMatches(matches);
+        console.log('Fetched matches:', matches);
       } catch (e) {
-        console.error(e);
+        console.error('Error fetching matches:', e);
       }
     }
 

--- a/server.js
+++ b/server.js
@@ -217,7 +217,7 @@ app.get('/api/teams', async (_req, res) => {
 app.get('/api/matches', async (_req, res) => {
   try {
     const { rows } = await pool.query(
-      'SELECT * FROM matches ORDER BY "timestamp" DESC LIMIT 50'
+      'SELECT id AS "matchId", "timestamp", clubs, players FROM matches ORDER BY "timestamp" DESC LIMIT 50'
     );
     res.json(rows);
   } catch (err) {


### PR DESCRIPTION
## Summary
- close `fetchClubMatches` and add debug logging for `/api/matches` in fixtures
- expose `matchId` field from `/api/matches` API

## Testing
- ⚠️ `npm install` (failed: ENOTEMPTY: directory not empty, rename)
- ⚠️ `npm test` (Cannot find module 'express')

------
https://chatgpt.com/codex/tasks/task_e_68a6baf89c3c832eb4424b5fcc1f9028