### PR TITLE
Add CORS support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,21 @@
 {
   "name": "fc-26-project-beta",
   "private": true,
-  "engines": { "node": ">=18" },
-  "scripts": { "start": "node server.js", "test": "NODE_ENV=test node --test" },
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "start": "node server.js",
+    "test": "NODE_ENV=test node --test"
+  },
   "dependencies": {
     "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
     "express": "^4.19.2",
     "express-session": "^1.17.3",
-    "uuid": "^9.0.1",
-    "pg": "^8.11.0",
+    "node-cron": "^3.0.2",
     "node-fetch": "^2.6.9",
-    "node-cron": "^3.0.2"
+    "pg": "^8.11.0",
+    "uuid": "^9.0.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,5 +1,23 @@
 const express = require('express');
 const session = require('express-session');
+let cors;
+try {
+  cors = require('cors');
+} catch {
+  // Fallback minimal CORS middleware if package isn't installed
+  cors = () => (req, res, next) => {
+    res.set('Access-Control-Allow-Origin', '*');
+    if (req.method === 'OPTIONS') {
+      res.set(
+        'Access-Control-Allow-Methods',
+        'GET,HEAD,PUT,PATCH,POST,DELETE'
+      );
+      res.set('Access-Control-Allow-Headers', 'Content-Type');
+      return res.status(204).end();
+    }
+    next();
+  };
+}
 const path = require('path');
 const pool = require('./db');
 const eaApi = require('./services/eaApi');
@@ -108,6 +126,7 @@ async function fetchClubPlayers(clubId) {
 
 const app = express();
 app.set('trust proxy', 1);
+app.use(cors({ origin: '*' }));
 app.use(
   session({
     secret: process.env.SESSION_SECRET || 'dev-secret',


### PR DESCRIPTION
## Summary
- add cors dependency
- add cors middleware before session setup with fallback

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68a6d0057c28832e9ecb6a4b04a95047