### PR TITLE
Proxy EA match fetch via backend

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -686,18 +686,12 @@ let friendliesFxCache  = [];
 let friendliesTeams    = [];
 let matchesCache       = [];
 
-// numeric club ids for league teams – used when fetching matches directly
+// numeric club ids for league teams – used when fetching matches
 const LEAGUE_CLUB_IDS = [
   "2491998","1527486","1969494","2086022","2462194","5098824",
   "4869810","576007","4933507","4824736","481847","3050467",
   "4154835","3638105","55408","4819681","35642"
 ];
-
-// headers resembling a browser request for EA endpoints
-const EA_FETCH_HEADERS = {
-  'Accept': 'application/json, text/plain, */*',
-  'Accept-Language': 'en-US,en;q=0.9'
-};
 
 // api
 async function apiGet(p){ const r = await fetch(API_BASE+p,{credentials:'include'}); if(!r.ok) throw new Error('HTTP '+r.status); return r.json(); }
@@ -998,8 +992,8 @@ async function refreshMatches(){
   const byId = {};
   for (const id of LEAGUE_CLUB_IDS){
     try{
-      const url = `https://proclubs.ea.com/api/fc/clubs/matches?matchType=leagueMatch&platform=common-gen5&clubIds=${id}`;
-      const res = await fetch(url,{ headers: EA_FETCH_HEADERS });
+      const url = `/api/ea/clubs/${id}/matches`;
+      const res = await fetch(url);
       if(!res.ok) throw new Error('EA '+res.status);
       const data = await res.json();
       const arr = data?.[id] || [];

--- a/server.js
+++ b/server.js
@@ -219,6 +219,26 @@ app.get('/api/ea/clubs/:clubId/info', async (req, res) => {
   }
 });
 
+// Proxy to fetch recent matches from EA API
+app.get('/api/ea/clubs/:clubId/matches', async (req, res) => {
+  const { clubId } = req.params;
+  if (!/^\d+$/.test(String(clubId))) {
+    return res.status(400).json({ error: 'Invalid clubId' });
+  }
+
+  try {
+    const url = `https://proclubs.ea.com/api/fc/clubs/matches?matchType=leagueMatch&platform=common-gen5&clubIds=${clubId}`;
+    const r = await fetchFn(url, { headers: EA_HEADERS });
+    if (!r.ok) throw new Error(`EA responded ${r.status}`);
+    res.json(await r.json());
+  } catch (err) {
+    console.error('EA matches fetch failed', err.message);
+    res
+      .status(502)
+      .json({ error: 'EA API request failed', details: err.message });
+  }
+});
+
 // Basic teams listing
 app.get('/api/teams', async (_req, res) => {
   try {


### PR DESCRIPTION
## Summary
- add `/api/ea/clubs/:clubId/matches` backend proxy to reach EA without CORS
- update teams page to fetch through backend and persist matches

## Testing
- `npm test` *(fails: Cannot find module 'express' / 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_68a6d491b65c832ead71acfc4c9d5d45