### PR TITLE
Use fetch to save matches in teams refresh

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -1006,7 +1006,10 @@ async function refreshMatches(){
   matchesCache = Object.values(byId);
   renderMatches();
   // persist after rendering
-  try{ await apiPost('/api/saveMatches', matchesCache); } catch(err){ console.warn('saveMatches failed', err); }
+  fetch('/api/saveMatches', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(matchesCache) })
+    .then(res => res.json())
+    .then(out => console.log('Saved matches:', out))
+    .catch(err => console.error('Save failed:', err));
 }
 function renderMatches(){
   const list = matchesCache.slice().sort((a,b)=>(b.timestamp||0)-(a.timestamp||0));


### PR DESCRIPTION
## Summary
- replace `apiPost` with a `fetch` request in `refreshMatches`
- log saved match results and report errors

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68a6d99894f0832eb59a39538be700a7