### PR TITLE
Render EA matches before persisting

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -984,6 +984,8 @@ const fixturesPublicList = document.getElementById('fixturesPublicList');
 async function refreshMatches(){
   const ids = teams.map(t=>t.id).filter(id=>/^\d+$/.test(String(id)));
   const map = new Map();
+  matchesCache = []; // clear any previous results
+  renderMatches(); // show loading state
 
   for (const id of ids){
     try{
@@ -992,13 +994,12 @@ async function refreshMatches(){
       const data = await res.json();
       const arr = data?.[id] || [];
       arr.forEach(m => { if (!map.has(m.matchId)) map.set(m.matchId, m); });
+      matchesCache = Array.from(map.values());
+      renderMatches(); // display before persisting
     }catch(err){
       console.error('EA matches fetch failed', id, err);
     }
   }
-
-  matchesCache = Array.from(map.values());
-  renderMatches();
 
   try{
     await fetch('/api/saveMatches',{


### PR DESCRIPTION
## Summary
- render EA-fetched matches in the fixtures UI as each club's data arrives
- reset match cache up front to provide loading state before persistence

## Testing
- `npm test` *(fails: Cannot find module 'express', after npm install: 403 Forbidden fetching cors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6eb9760ac832e8e3681c2f9a24bfc