### PR TITLE
feat: display EA fixtures and store matches

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -365,7 +365,7 @@ h2{margin:0 0 10px}
   <!-- FIXTURES (PUBLIC) -->
   <section id="fixtures-public" style="display:none">
     <h2>Fixtures</h2>
-    <div id="matchesList" class="fx-list" style="margin-top:10px"></div>
+    <div id="fixtures" class="fx-list" style="margin-top:10px"></div>
     <div id="fixturesPublicList" class="fx-list" style="margin-top:10px"></div>
   </section>
 
@@ -978,53 +978,46 @@ document.getElementById('btnUnlistFA').onclick = async ()=>{
 // =======================
 //   FIXTURES — PUBLIC
 // =======================
-const matchesList = document.getElementById('matchesList');
+const fixturesEl = document.getElementById('fixtures');
 const fixturesPublicList = document.getElementById('fixturesPublicList');
 
 async function refreshMatches(){
-  const ids = teams.map(t=>t.id).filter(id=>/^\d+$/.test(String(id)));
-  const map = new Map();
-  matchesCache = []; // clear any previous results
-  renderMatches(); // show loading state
-
-  for (const id of ids){
-    try{
-      const res = await fetch(`/api/ea/clubs/${encodeURIComponent(id)}/matches`);
-      if(!res.ok) throw new Error('HTTP '+res.status);
-      const data = await res.json();
-      const arr = data?.[id] || [];
-      arr.forEach(m => { if (!map.has(m.matchId)) map.set(m.matchId, m); });
-      matchesCache = Array.from(map.values());
-      renderMatches(); // display before persisting
-    }catch(err){
-      console.error('EA matches fetch failed', id, err);
-    }
-  }
-
   try{
-    await fetch('/api/saveMatches',{
-      method:'POST',
-      headers:{'Content-Type':'application/json'},
-      body:JSON.stringify(matchesCache)
+    const res = await fetch('/api/ea/matches');
+    if(!res.ok) throw new Error('HTTP '+res.status);
+    const data = await res.json();
+    matchesCache = Array.isArray(data) ? data : [];
+    renderMatches();
+    await fetch('/api/saveMatches', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(matchesCache)
     });
-  }catch(err){
-    console.error('Persist matches failed', err);
+  } catch(err){
+    console.error('Error fetching matches:', err);
   }
 }
+
 function renderMatches(){
-  const list = matchesCache.slice().sort((a,b)=>(b.timestamp||0)-(a.timestamp||0));
-  matchesList.innerHTML = list.length ? list.map(m=>{
-    const id = m.matchId;
-    const date = fmtDate(m.timestamp);
-    const hn = m.clubs?.home?.name || '';
-    const an = m.clubs?.away?.name || '';
-    const hs = m.clubs?.home?.score ?? '';
-    const as = m.clubs?.away?.score ?? '';
-    const hp = (m.players?.home || []).map(p=>escapeHtml(p.name || p.playername || p.personaName || p.id || '')).join(', ');
-    const ap = (m.players?.away || []).map(p=>escapeHtml(p.name || p.playername || p.personaName || p.id || '')).join(', ');
-    const playersHtml = hp || ap ? `<div class="meta">${hp} • ${ap}</div>` : '';
-    return `<div class="fx"><div><strong>Match ${escapeHtml(id)}</strong><div class="meta">Date: ${escapeHtml(date)}</div><div class="fx-vs"><span class="fx-team"><span>${escapeHtml(hn)}</span></span><span class="muted">${escapeHtml(hs)} – ${escapeHtml(as)}</span><span class="fx-team"><span>${escapeHtml(an)}</span></span></div>${playersHtml}</div></div>`;
-  }).join('') : `<div class="muted">No matches.</div>`;
+  fixturesEl.innerHTML = '';
+  if (!matchesCache.length) {
+    fixturesEl.innerHTML = '<div class="muted">No matches.</div>';
+    return;
+  }
+  matchesCache.forEach(match => {
+    const clubs = Object.values(match.clubs || {});
+    if (clubs.length < 2) return;
+    const [clubA, clubB] = clubs;
+    const date = fmtDate(match.timestamp * 1000);
+    const card = document.createElement('div');
+    card.className = 'match-card';
+    card.innerHTML = `
+      <h3>Match ${match.matchId}</h3>
+      <p>Date: ${date}</p>
+      <p>${clubA.name} ${clubA.score} - ${clubB.score} ${clubB.name}</p>
+    `;
+    fixturesEl.appendChild(card);
+  });
 }
 
 async function refreshFixturesPublic(){

--- a/server.js
+++ b/server.js
@@ -239,6 +239,27 @@ app.get('/api/ea/clubs/:clubId/matches', async (req, res) => {
   }
 });
 
+// Aggregate recent matches for default club list
+app.get('/api/ea/matches', async (_req, res) => {
+  try {
+    const data = await eaApi.fetchClubLeagueMatches(CLUB_IDS);
+    const map = new Map();
+    Object.values(data || {}).forEach(arr => {
+      if (Array.isArray(arr)) {
+        arr.forEach(m => {
+          if (!map.has(m.matchId)) map.set(m.matchId, m);
+        });
+      }
+    });
+    res.json(Array.from(map.values()));
+  } catch (err) {
+    console.error('EA matches fetch failed', err.message || err);
+    res
+      .status(err.status || 502)
+      .json({ error: 'EA API request failed', details: err.message || err.error });
+  }
+});
+
 // Basic teams listing
 app.get('/api/teams', async (_req, res) => {
   try {

--- a/test/eaMatches.test.js
+++ b/test/eaMatches.test.js
@@ -1,0 +1,42 @@
+const { test, mock } = require('node:test');
+const assert = require('assert');
+
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+
+const eaApi = require('../services/eaApi');
+const app = require('../server');
+
+async function withServer(fn) {
+  const server = app.listen(0);
+  try {
+    const port = server.address().port;
+    await fn(port);
+  } finally {
+    server.close();
+  }
+}
+
+test('aggregates matches from multiple clubs', async () => {
+  const stub = mock.method(eaApi, 'fetchClubLeagueMatches', async () => ({
+    '111': [
+      { matchId: '1', timestamp: 1, clubs: { a: { name: 'A', score: '1' }, b: { name: 'B', score: '0' } }, players: {} },
+      { matchId: '2', timestamp: 2, clubs: {}, players: {} }
+    ],
+    '222': [
+      { matchId: '2', timestamp: 2, clubs: {}, players: {} },
+      { matchId: '3', timestamp: 3, clubs: {}, players: {} }
+    ]
+  }));
+
+  await withServer(async port => {
+    const res = await fetch(`http://localhost:${port}/api/ea/matches`);
+    const body = await res.json();
+    assert.deepStrictEqual(body, [
+      { matchId: '1', timestamp: 1, clubs: { a: { name: 'A', score: '1' }, b: { name: 'B', score: '0' } }, players: {} },
+      { matchId: '2', timestamp: 2, clubs: {}, players: {} },
+      { matchId: '3', timestamp: 3, clubs: {}, players: {} }
+    ]);
+  });
+
+  stub.mock.restore();
+});


### PR DESCRIPTION
## Summary
- aggregate EA match results via new `/api/ea/matches`
- render EA fixtures in teams page and persist to backend
- test route behavior with match aggregation

## Testing
- `npm test` *(fails: Cannot find module 'express', Cannot find module 'pg')*


------
https://chatgpt.com/codex/tasks/task_e_68a6f059b4e4832eb812df234f7a4dd2