### PR TITLE
Normalize EA match fetching and rendering

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -365,7 +365,7 @@ h2{margin:0 0 10px}
   <!-- FIXTURES (PUBLIC) -->
   <section id="fixtures-public" style="display:none">
     <h2>Fixtures</h2>
-    <div id="matchesList" class="fx-list" style="margin-top:10px"></div>
+    <div id="fixtures" class="fx-list" style="margin-top:10px"></div>
     <div id="fixturesPublicList" class="fx-list" style="margin-top:10px"></div>
   </section>
 
@@ -978,53 +978,46 @@ document.getElementById('btnUnlistFA').onclick = async ()=>{
 // =======================
 //   FIXTURES — PUBLIC
 // =======================
-const matchesList = document.getElementById('matchesList');
+const fixturesEl = document.getElementById('fixtures');
 const fixturesPublicList = document.getElementById('fixturesPublicList');
 
 async function refreshMatches(){
-  const ids = teams.map(t=>t.id).filter(id=>/^\d+$/.test(String(id)));
-  const map = new Map();
-  matchesCache = []; // clear any previous results
-  renderMatches(); // show loading state
-
-  for (const id of ids){
-    try{
-      const res = await fetch(`/api/ea/clubs/${encodeURIComponent(id)}/matches`);
-      if(!res.ok) throw new Error('HTTP '+res.status);
-      const data = await res.json();
-      const arr = data?.[id] || [];
-      arr.forEach(m => { if (!map.has(m.matchId)) map.set(m.matchId, m); });
-      matchesCache = Array.from(map.values());
-      renderMatches(); // display before persisting
-    }catch(err){
-      console.error('EA matches fetch failed', id, err);
-    }
-  }
-
   try{
-    await fetch('/api/saveMatches',{
-      method:'POST',
-      headers:{'Content-Type':'application/json'},
-      body:JSON.stringify(matchesCache)
+    const res = await fetch('/api/ea/matches');
+    if(!res.ok) throw new Error('HTTP '+res.status);
+    const data = await res.json();
+    matchesCache = Array.isArray(data) ? data : [];
+    renderMatches();
+    await fetch('/api/saveMatches', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(matchesCache)
     });
-  }catch(err){
-    console.error('Persist matches failed', err);
+  } catch(err){
+    console.error('Error fetching matches:', err);
   }
 }
+
 function renderMatches(){
-  const list = matchesCache.slice().sort((a,b)=>(b.timestamp||0)-(a.timestamp||0));
-  matchesList.innerHTML = list.length ? list.map(m=>{
-    const id = m.matchId;
-    const date = fmtDate(m.timestamp);
-    const hn = m.clubs?.home?.name || '';
-    const an = m.clubs?.away?.name || '';
-    const hs = m.clubs?.home?.score ?? '';
-    const as = m.clubs?.away?.score ?? '';
-    const hp = (m.players?.home || []).map(p=>escapeHtml(p.name || p.playername || p.personaName || p.id || '')).join(', ');
-    const ap = (m.players?.away || []).map(p=>escapeHtml(p.name || p.playername || p.personaName || p.id || '')).join(', ');
-    const playersHtml = hp || ap ? `<div class="meta">${hp} • ${ap}</div>` : '';
-    return `<div class="fx"><div><strong>Match ${escapeHtml(id)}</strong><div class="meta">Date: ${escapeHtml(date)}</div><div class="fx-vs"><span class="fx-team"><span>${escapeHtml(hn)}</span></span><span class="muted">${escapeHtml(hs)} – ${escapeHtml(as)}</span><span class="fx-team"><span>${escapeHtml(an)}</span></span></div>${playersHtml}</div></div>`;
-  }).join('') : `<div class="muted">No matches.</div>`;
+  fixturesEl.innerHTML = '';
+  if (!matchesCache.length) {
+    fixturesEl.innerHTML = '<div class="muted">No matches.</div>';
+    return;
+  }
+  matchesCache.forEach(match => {
+    const home = match.homeClub;
+    const away = match.awayClub;
+    if (!home || !away) return;
+    const date = fmtDate(match.timestamp * 1000);
+    const card = document.createElement('div');
+    card.className = 'match-card';
+    card.innerHTML = `
+      <h3>Match ${escapeHtml(match.matchId)}</h3>
+      <p>Date: ${date}</p>
+      <p>${escapeHtml(home.name)} ${home.score} - ${away.score} ${escapeHtml(away.name)}</p>
+    `;
+    fixturesEl.appendChild(card);
+  });
 }
 
 async function refreshFixturesPublic(){

--- a/server.js
+++ b/server.js
@@ -239,6 +239,69 @@ app.get('/api/ea/clubs/:clubId/matches', async (req, res) => {
   }
 });
 
+function normalizeMatch(m) {
+  const clubIds = Object.keys(m.clubs || {});
+  if (clubIds.length < 2) return null;
+  const [homeId, awayId] = clubIds;
+  const homeRaw = m.clubs[homeId] || {};
+  const awayRaw = m.clubs[awayId] || {};
+
+  const players = [];
+  for (const [clubId, clubPlayers] of Object.entries(m.players || {})) {
+    for (const [playerId, p] of Object.entries(clubPlayers || {})) {
+      players.push({
+        clubId,
+        playerId,
+        name: p.playername || p.name || p.personaName || '',
+        pos: p.pos || p.position || '',
+        rating: p.rating != null ? Number(p.rating) : undefined,
+        goals: p.goals != null ? Number(p.goals) : 0,
+        assists: p.assists != null ? Number(p.assists) : 0,
+      });
+    }
+  }
+
+  return {
+    matchId: String(m.matchId),
+    timestamp: Number(m.timestamp),
+    homeClub: {
+      id: String(homeId),
+      name: homeRaw.name,
+      score: homeRaw.score != null ? Number(homeRaw.score) : 0,
+    },
+    awayClub: {
+      id: String(awayId),
+      name: awayRaw.name,
+      score: awayRaw.score != null ? Number(awayRaw.score) : 0,
+    },
+    players,
+  };
+}
+
+// Aggregate recent matches for default club list
+app.get('/api/ea/matches', async (_req, res) => {
+  try {
+    const all = [];
+    for (const id of CLUB_IDS) {
+      const arr = await eaApi.fetchRecentLeagueMatches(id);
+      if (Array.isArray(arr)) all.push(...arr);
+    }
+    const map = new Map();
+    for (const m of all) {
+      if (!map.has(m.matchId)) map.set(m.matchId, m);
+    }
+    const out = Array.from(map.values())
+      .map(normalizeMatch)
+      .filter(Boolean);
+    res.json(out);
+  } catch (err) {
+    console.error('EA matches fetch failed', err.message || err);
+    res
+      .status(err.status || 502)
+      .json({ error: 'EA API request failed', details: err.message || err.error });
+  }
+});
+
 // Basic teams listing
 app.get('/api/teams', async (_req, res) => {
   try {
@@ -295,7 +358,12 @@ app.post('/api/saveMatches', async (req, res) => {
         [
           match.matchId,
           match.timestamp,
-          JSON.stringify(match.clubs),
+          JSON.stringify(
+            match.clubs || {
+              home: match.homeClub,
+              away: match.awayClub,
+            }
+          ),
           JSON.stringify(match.players),
           JSON.stringify(match)
         ]

--- a/test/eaMatches.test.js
+++ b/test/eaMatches.test.js
@@ -1,0 +1,120 @@
+const { test, mock } = require('node:test');
+const assert = require('assert');
+
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+process.env.LEAGUE_CLUB_IDS = '111,222';
+
+const eaApi = require('../services/eaApi');
+const app = require('../server');
+
+async function withServer(fn) {
+  const server = app.listen(0);
+  try {
+    const port = server.address().port;
+    await fn(port);
+  } finally {
+    server.close();
+  }
+}
+
+test('aggregates and normalizes matches from multiple clubs', async () => {
+  const stub = mock.method(
+    eaApi,
+    'fetchRecentLeagueMatches',
+    async clubId => {
+      if (clubId === '111')
+        return [
+          {
+            matchId: '1',
+            timestamp: 1,
+            clubs: {
+              a: { name: 'A', score: '1' },
+              b: { name: 'B', score: '0' },
+            },
+            players: {
+              a: {
+                p1: {
+                  playername: 'P1',
+                  pos: 'F',
+                  rating: '9.1',
+                  goals: '1',
+                  assists: '0',
+                },
+              },
+            },
+          },
+          {
+            matchId: '2',
+            timestamp: 2,
+            clubs: {
+              c: { name: 'C', score: '0' },
+              d: { name: 'D', score: '2' },
+            },
+            players: {},
+          },
+        ];
+      if (clubId === '222')
+        return [
+          {
+            matchId: '2',
+            timestamp: 2,
+            clubs: {
+              c: { name: 'C', score: '0' },
+              d: { name: 'D', score: '2' },
+            },
+            players: {},
+          },
+          {
+            matchId: '3',
+            timestamp: 3,
+            clubs: {
+              e: { name: 'E', score: '1' },
+              f: { name: 'F', score: '1' },
+            },
+            players: {},
+          },
+        ];
+      return [];
+    }
+  );
+
+  await withServer(async port => {
+    const res = await fetch(`http://localhost:${port}/api/ea/matches`);
+    const body = await res.json();
+    assert.deepStrictEqual(body, [
+      {
+        matchId: '1',
+        timestamp: 1,
+        homeClub: { id: 'a', name: 'A', score: 1 },
+        awayClub: { id: 'b', name: 'B', score: 0 },
+        players: [
+          {
+            clubId: 'a',
+            playerId: 'p1',
+            name: 'P1',
+            pos: 'F',
+            rating: 9.1,
+            goals: 1,
+            assists: 0,
+          },
+        ],
+      },
+      {
+        matchId: '2',
+        timestamp: 2,
+        homeClub: { id: 'c', name: 'C', score: 0 },
+        awayClub: { id: 'd', name: 'D', score: 2 },
+        players: [],
+      },
+      {
+        matchId: '3',
+        timestamp: 3,
+        homeClub: { id: 'e', name: 'E', score: 1 },
+        awayClub: { id: 'f', name: 'F', score: 1 },
+        players: [],
+      },
+    ]);
+  });
+
+  stub.mock.restore();
+});


### PR DESCRIPTION
## Summary
- fetch and merge EA matches per club, normalizing to home/away and flat player stats
- store and render normalized match objects on the frontend
- cover match aggregation/normalization with tests

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f059b4e4832eb812df234f7a4dd2