### PR TITLE
Fix syntax errors causing build failures

### DIFF
--- a/server.js
+++ b/server.js
@@ -282,23 +282,6 @@ function normalizeMatch(m) {
 // Aggregate recent matches for default club list
 app.get('/api/ea/matches', async (_req, res) => {
   try {
-    const all = [];
-    for (const id of CLUB_IDS) {
-      const arr = await eaApi.fetchRecentLeagueMatches(id);
-      if (Array.isArray(arr)) all.push(...arr);
-    }
-    const map = new Map();
-    for (const m of all) {
-      if (!map.has(m.matchId)) map.set(m.matchId, m);
-    }
-    const out = Array.from(map.values())
-      .map(normalizeMatch)
-      .filter(Boolean);
-    res.json(out);
-
-// Aggregate recent matches for default club list
-app.get('/api/ea/matches', async (_req, res) => {
-  try {
     const data = await eaApi.fetchClubLeagueMatches(CLUB_IDS);
     const map = new Map();
     Object.values(data || {}).forEach(arr => {
@@ -309,7 +292,6 @@ app.get('/api/ea/matches', async (_req, res) => {
       }
     });
     res.json(Array.from(map.values()));
-
   } catch (err) {
     console.error('EA matches fetch failed', err.message || err);
     res

--- a/test/eaMatches.test.js
+++ b/test/eaMatches.test.js
@@ -2,10 +2,7 @@ const { test, mock } = require('node:test');
 const assert = require('assert');
 
 process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
-
 process.env.LEAGUE_CLUB_IDS = '111,222';
-
-
 
 const eaApi = require('../services/eaApi');
 const app = require('../server');
@@ -20,68 +17,6 @@ async function withServer(fn) {
   }
 }
 
-
-test('aggregates and normalizes matches from multiple clubs', async () => {
-  const stub = mock.method(
-    eaApi,
-    'fetchRecentLeagueMatches',
-    async clubId => {
-      if (clubId === '111')
-        return [
-          {
-            matchId: '1',
-            timestamp: 1,
-            clubs: {
-              a: { name: 'A', score: '1' },
-              b: { name: 'B', score: '0' },
-            },
-            players: {
-              a: {
-                p1: {
-                  playername: 'P1',
-                  pos: 'F',
-                  rating: '9.1',
-                  goals: '1',
-                  assists: '0',
-                },
-              },
-            },
-          },
-          {
-            matchId: '2',
-            timestamp: 2,
-            clubs: {
-              c: { name: 'C', score: '0' },
-              d: { name: 'D', score: '2' },
-            },
-            players: {},
-          },
-        ];
-      if (clubId === '222')
-        return [
-          {
-            matchId: '2',
-            timestamp: 2,
-            clubs: {
-              c: { name: 'C', score: '0' },
-              d: { name: 'D', score: '2' },
-            },
-            players: {},
-          },
-          {
-            matchId: '3',
-            timestamp: 3,
-            clubs: {
-              e: { name: 'E', score: '1' },
-              f: { name: 'F', score: '1' },
-            },
-            players: {},
-          },
-        ];
-      return [];
-    }
-  );
-
 test('aggregates matches from multiple clubs', async () => {
   const stub = mock.method(eaApi, 'fetchClubLeagueMatches', async () => ({
     '111': [
@@ -94,12 +29,10 @@ test('aggregates matches from multiple clubs', async () => {
     ]
   }));
 
-
   await withServer(async port => {
     const res = await fetch(`http://localhost:${port}/api/ea/matches`);
     const body = await res.json();
     assert.deepStrictEqual(body, [
-
       {
         matchId: '1',
         timestamp: 1,
@@ -131,13 +64,9 @@ test('aggregates matches from multiple clubs', async () => {
         awayClub: { id: 'f', name: 'F', score: 1 },
         players: [],
       },
-
-      { matchId: '1', timestamp: 1, clubs: { a: { name: 'A', score: '1' }, b: { name: 'B', score: '0' } }, players: {} },
-      { matchId: '2', timestamp: 2, clubs: {}, players: {} },
-      { matchId: '3', timestamp: 3, clubs: {}, players: {} }
-
     ]);
   });
 
   stub.mock.restore();
 });
+


### PR DESCRIPTION
## Summary
- remove duplicate ea matches route and close all open blocks
- replace incomplete eaMatches test with valid aggregation test

## Testing
- `npm test` *(fails: Cannot find module 'express' / 'pg')*


------
https://chatgpt.com/codex/tasks/task_e_68a6f7eadbe8832e92a6dbb14e6f211b