### PR TITLE
Fix EA matches fetch and response normalization

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -986,13 +986,15 @@ async function refreshMatches(){
     const res = await fetch('/api/ea/matches');
     if(!res.ok) throw new Error('HTTP '+res.status);
     const data = await res.json();
-    matchesCache = Array.isArray(data) ? data : [];
-    renderMatches();
-    await fetch('/api/saveMatches', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(matchesCache)
-    });
+    if(Array.isArray(data) && data.length){
+      matchesCache = data;
+      renderMatches();
+      await fetch('/api/saveMatches', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(matchesCache)
+      });
+    }
   } catch(err){
     console.error('Error fetching matches:', err);
   }
@@ -1005,28 +1007,16 @@ function renderMatches(){
     return;
   }
   matchesCache.forEach(match => {
-
-    const home = match.homeClub;
-    const away = match.awayClub;
+    const home = match.homeTeam;
+    const away = match.awayTeam;
     if (!home || !away) return;
-
-    const clubs = Object.values(match.clubs || {});
-    if (clubs.length < 2) return;
-    const [clubA, clubB] = clubs;
-
     const date = fmtDate(match.timestamp * 1000);
     const card = document.createElement('div');
     card.className = 'match-card';
     card.innerHTML = `
-
       <h3>Match ${escapeHtml(match.matchId)}</h3>
       <p>Date: ${date}</p>
       <p>${escapeHtml(home.name)} ${home.score} - ${away.score} ${escapeHtml(away.name)}</p>
-
-      <h3>Match ${match.matchId}</h3>
-      <p>Date: ${date}</p>
-      <p>${clubA.name} ${clubA.score} - ${clubB.score} ${clubB.name}</p>
-
     `;
     fixturesEl.appendChild(card);
   });

--- a/test/eaMatches.test.js
+++ b/test/eaMatches.test.js
@@ -18,16 +18,45 @@ async function withServer(fn) {
 }
 
 test('aggregates matches from multiple clubs', async () => {
-  const stub = mock.method(eaApi, 'fetchClubLeagueMatches', async () => ({
-    '111': [
-      { matchId: '1', timestamp: 1, clubs: { a: { name: 'A', score: '1' }, b: { name: 'B', score: '0' } }, players: {} },
-      { matchId: '2', timestamp: 2, clubs: {}, players: {} }
-    ],
-    '222': [
-      { matchId: '2', timestamp: 2, clubs: {}, players: {} },
-      { matchId: '3', timestamp: 3, clubs: {}, players: {} }
-    ]
-  }));
+  const stub = mock.method(eaApi, 'fetchRecentLeagueMatches', async clubId => {
+    if (clubId === '111') {
+      return [
+        {
+          matchId: '1',
+          timestamp: 1,
+          clubs: { a: { name: 'A', score: '1' }, b: { name: 'B', score: '0' } },
+          players: {
+            a: {
+              p1: { name: 'P1', pos: 'F', rating: '9.1', goals: '1', assists: '0' },
+            },
+          },
+        },
+        {
+          matchId: '2',
+          timestamp: 2,
+          clubs: { c: { name: 'C', score: '0' }, d: { name: 'D', score: '2' } },
+          players: {},
+        },
+      ];
+    }
+    if (clubId === '222') {
+      return [
+        {
+          matchId: '2',
+          timestamp: 2,
+          clubs: { c: { name: 'C', score: '0' }, d: { name: 'D', score: '2' } },
+          players: {},
+        },
+        {
+          matchId: '3',
+          timestamp: 3,
+          clubs: { e: { name: 'E', score: '1' }, f: { name: 'F', score: '1' } },
+          players: {},
+        },
+      ];
+    }
+    return [];
+  });
 
   await withServer(async port => {
     const res = await fetch(`http://localhost:${port}/api/ea/matches`);
@@ -36,8 +65,8 @@ test('aggregates matches from multiple clubs', async () => {
       {
         matchId: '1',
         timestamp: 1,
-        homeClub: { id: 'a', name: 'A', score: 1 },
-        awayClub: { id: 'b', name: 'B', score: 0 },
+        homeTeam: { clubId: 'a', name: 'A', score: 1 },
+        awayTeam: { clubId: 'b', name: 'B', score: 0 },
         players: [
           {
             clubId: 'a',
@@ -53,15 +82,15 @@ test('aggregates matches from multiple clubs', async () => {
       {
         matchId: '2',
         timestamp: 2,
-        homeClub: { id: 'c', name: 'C', score: 0 },
-        awayClub: { id: 'd', name: 'D', score: 2 },
+        homeTeam: { clubId: 'c', name: 'C', score: 0 },
+        awayTeam: { clubId: 'd', name: 'D', score: 2 },
         players: [],
       },
       {
         matchId: '3',
         timestamp: 3,
-        homeClub: { id: 'e', name: 'E', score: 1 },
-        awayClub: { id: 'f', name: 'F', score: 1 },
+        homeTeam: { clubId: 'e', name: 'E', score: 1 },
+        awayTeam: { clubId: 'f', name: 'F', score: 1 },
         players: [],
       },
     ]);


### PR DESCRIPTION
## Summary
- Fetch EA league matches per club to avoid bulk request errors
- Normalize match payload to `homeTeam`, `awayTeam`, and player stats
- Update frontend fixtures to consume new normalized API

## Testing
- ⚠️ `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68a6fd6d6440832e8c43912c31f71659