### PR TITLE
Fetch EA matches per club

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -365,7 +365,7 @@ h2{margin:0 0 10px}
   <!-- FIXTURES (PUBLIC) -->
   <section id="fixtures-public" style="display:none">
     <h2>Fixtures</h2>
-    <div id="fixtures" class="fx-list" style="margin-top:10px"></div>
+    <div id="matchesList" class="fx-list" style="margin-top:10px"></div>
     <div id="fixturesPublicList" class="fx-list" style="margin-top:10px"></div>
   </section>
 
@@ -684,6 +684,7 @@ let fixturesPublicCache = [];
 let fixturesSchedCache  = [];
 let friendliesFxCache  = [];
 let friendliesTeams    = [];
+const CLUB_IDS = [35642, 3638105, 1527486, 55408];
 let matchesCache       = [];
 
 // api
@@ -978,48 +979,70 @@ document.getElementById('btnUnlistFA').onclick = async ()=>{
 // =======================
 //   FIXTURES — PUBLIC
 // =======================
-const fixturesEl = document.getElementById('fixtures');
+const matchesList = document.getElementById('matchesList');
 const fixturesPublicList = document.getElementById('fixturesPublicList');
 
-async function refreshMatches(){
-  try{
-    const res = await fetch('/api/ea/matches');
-    if(!res.ok) throw new Error('HTTP '+res.status);
-    const data = await res.json();
-    if(Array.isArray(data) && data.length){
-      matchesCache = data;
-      renderMatches();
-      await fetch('/api/saveMatches', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(matchesCache)
-      });
+async function refreshMatches() {
+  matchesCache = [];
+
+  for (const id of CLUB_IDS) {
+    try {
+      const res = await fetch(`/api/ea/matches/${id}`);
+      if (!res.ok) throw new Error(`Failed for club ${id}`);
+      const data = await res.json();
+
+      if (Array.isArray(data)) {
+        matchesCache.push(...data);
+      } else {
+        console.warn(`Unexpected format for club ${id}`, data);
+      }
+    } catch (err) {
+      console.error(`Club ${id} fetch failed`, err);
     }
-  } catch(err){
-    console.error('Error fetching matches:', err);
+  }
+
+  renderMatches();
+
+  try {
+    await fetch('/api/saveMatches', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(matchesCache)
+    });
+  } catch (err) {
+    console.error('Failed to save matches', err);
   }
 }
 
-function renderMatches(){
-  fixturesEl.innerHTML = '';
+function renderMatches() {
+  matchesList.innerHTML = '';
+
   if (!matchesCache.length) {
-    fixturesEl.innerHTML = '<div class="muted">No matches.</div>';
+    matchesList.innerHTML = '<p>No matches available.</p>';
     return;
   }
-  matchesCache.forEach(match => {
-    const home = match.homeTeam;
-    const away = match.awayTeam;
-    if (!home || !away) return;
-    const date = fmtDate(match.timestamp * 1000);
+
+  matchesCache.sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
+
+  for (const match of matchesCache) {
     const card = document.createElement('div');
     card.className = 'match-card';
+
+    const home = match.clubs ? Object.values(match.clubs)[0]?.name || 'Home' : 'Home';
+    const away = match.clubs ? Object.values(match.clubs)[1]?.name || 'Away' : 'Away';
+    const score = `${Object.values(match.clubs || {})[0]?.score ?? 0} - ${Object.values(match.clubs || {})[1]?.score ?? 0}`;
+    const date = match.timestamp ? new Date(match.timestamp * 1000).toLocaleString() : 'Unknown';
+
     card.innerHTML = `
-      <h3>Match ${escapeHtml(match.matchId)}</h3>
-      <p>Date: ${date}</p>
-      <p>${escapeHtml(home.name)} ${home.score} - ${away.score} ${escapeHtml(away.name)}</p>
+      <div class="match-info">
+        <span class="teams">${home} vs ${away}</span>
+        <span class="score">${score}</span>
+        <span class="date">${date}</span>
+      </div>
     `;
-    fixturesEl.appendChild(card);
-  });
+
+    matchesList.appendChild(card);
+  }
 }
 
 async function refreshFixturesPublic(){


### PR DESCRIPTION
## Summary
- add server endpoint to fetch EA league matches for a single club
- query club ids individually on the frontend and render sorted match cards

## Testing
- `npm test` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68a70528a574832e941c3f5a0a5fbcab