### PR TITLE
Serve matches from DB with background refresh

### DIFF
--- a/db.js
+++ b/db.js
@@ -56,15 +56,15 @@ ensureTable(
   'ea_last_matches'
 );
 
-// Recent match history fetched from EA API
+// Recent match history fetched from EA API. One row per match per club.
 ensureTable(
   `
   CREATE TABLE IF NOT EXISTS matches (
     id BIGINT PRIMARY KEY,
-    "timestamp" TIMESTAMPTZ,
-    clubs JSONB,
-    players JSONB,
-    raw JSONB
+    club_id BIGINT NOT NULL,
+    timestamp BIGINT NOT NULL,
+    data JSONB NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now()
   )
 `,
   'matches'

--- a/scripts/fetchMatches.js
+++ b/scripts/fetchMatches.js
@@ -17,15 +17,12 @@ async function main() {
     const matches = Array.isArray(data[clubId]) ? data[clubId] : [];
     for (const m of matches) {
       const id = Number(m.matchId);
-      const ts = m.timestamp
-        ? new Date(m.timestamp).toISOString()
-        : (m.matchDate ? new Date(m.matchDate).toISOString() : null);
       try {
         const { rowCount } = await pool.query(
-          `INSERT INTO matches (id, timestamp, clubs, players, raw)
-           VALUES ($1,$2,$3,$4,$5)
+          `INSERT INTO matches (id, club_id, timestamp, data)
+           VALUES ($1,$2,$3,$4)
            ON CONFLICT (id) DO NOTHING`,
-          [id, ts, m.clubs || { home: m.home, away: m.away }, m.players || null, m]
+          [id, Number(clubId), m.timestamp, m]
         );
         inserted += rowCount;
       } catch (err) {

--- a/services/matches.js
+++ b/services/matches.js
@@ -20,16 +20,10 @@ async function saveLeagueMatches(clubId, pool) {
   const matches = await fetchLeagueMatches(clubId);
   for (const m of matches) {
     await pool.query(
-      `INSERT INTO matches (id, "timestamp", clubs, players, raw)
-       VALUES ($1, to_timestamp($2 / 1000), $3, $4, $5)
+      `INSERT INTO matches (id, club_id, timestamp, data)
+       VALUES ($1, $2, $3, $4)
        ON CONFLICT (id) DO NOTHING`,
-      [
-        String(m.matchId),
-        m.timestamp,
-        JSON.stringify(m.clubs || {}),
-        JSON.stringify(m.players || {}),
-        JSON.stringify(m)
-      ]
+      [String(m.matchId), clubId, m.timestamp, JSON.stringify(m)]
     );
   }
 }

--- a/test/matches.test.js
+++ b/test/matches.test.js
@@ -10,10 +10,9 @@ const queryStub = mock.method(pool, 'query', async sql => {
       rows: [
         {
           id: '1',
-          timestamp: '2024-01-01T00:00:00Z',
-          clubs: { '123': {} },
-          players: {},
-          raw: { clubIds: ['123'] }
+          club_id: '123',
+          timestamp: 123,
+          data: { matchId: '1', foo: 'bar' }
         }
       ]
     };
@@ -37,15 +36,7 @@ test('serves recent matches from db', async () => {
   await withServer(async port => {
     const res = await fetch(`http://localhost:${port}/api/matches`);
     const body = await res.json();
-    assert.deepStrictEqual(body, [
-      {
-        id: '1',
-        timestamp: '2024-01-01T00:00:00Z',
-        clubs: { '123': {} },
-        players: {},
-        raw: { clubIds: ['123'] }
-      }
-    ]);
+    assert.deepStrictEqual(body, [{ matchId: '1', foo: 'bar' }]);
   });
   queryStub.mock.restore();
 });

--- a/utils/matches.js
+++ b/utils/matches.js
@@ -25,16 +25,10 @@ async function fetchAndStoreMatches(clubIds = [], pool, delayMs = 300) {
       const matches = await fetchMatchesForClub(id);
       for (const m of matches) {
         await pool.query(
-          `INSERT INTO matches (id, "timestamp", clubs, players, raw)
-           VALUES ($1, to_timestamp($2 / 1000), $3, $4, $5)
+          `INSERT INTO matches (id, club_id, timestamp, data)
+           VALUES ($1, $2, $3, $4)
            ON CONFLICT (id) DO NOTHING`,
-          [
-            String(m.matchId),
-            m.timestamp,
-            JSON.stringify(m.clubs || {}),
-            JSON.stringify(m.players || {}),
-            JSON.stringify(m),
-          ]
+          [String(m.matchId), id, m.timestamp, JSON.stringify(m)]
         );
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- Fetch EA match data in the background and store it in Postgres
- Serve `/api/matches` directly from the `matches` table for instant responses
- Define a simplified `matches` table schema and adjust utilities and tests

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68a73d14e15c832e95aec2ba8275029b