### PR TITLE
Wrap matches response for API parity

### DIFF
--- a/server.js
+++ b/server.js
@@ -314,7 +314,8 @@ app.get('/api/matches', async (_req, res) => {
     const { rows } = await pool.query(
       'SELECT id, club_id, timestamp, data FROM matches ORDER BY timestamp DESC LIMIT 50'
     );
-    res.status(200).json(rows.map(r => r.data));
+    const matches = rows.map(r => r.data);
+    res.status(200).json({ matches });
   } catch (err) {
     console.error('Failed to fetch matches:', err);
     res.status(500).json({ error: 'Failed to fetch matches' });

--- a/test/matches.test.js
+++ b/test/matches.test.js
@@ -34,9 +34,9 @@ async function withServer(fn) {
 
 test('serves recent matches from db', async () => {
   await withServer(async port => {
-    const res = await fetch(`http://localhost:${port}/api/matches`);
-    const body = await res.json();
-    assert.deepStrictEqual(body, [{ matchId: '1', foo: 'bar' }]);
+      const res = await fetch(`http://localhost:${port}/api/matches`);
+      const body = await res.json();
+      assert.deepStrictEqual(body, { matches: [{ matchId: '1', foo: 'bar' }] });
+    });
+    queryStub.mock.restore();
   });
-  queryStub.mock.restore();
-});


### PR DESCRIPTION
## Summary
- Wrap `/api/matches` response in an object under `matches`
- Update matches endpoint test to expect new structure

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm test` (fails: Cannot find module 'express')

------
https://chatgpt.com/codex/tasks/task_e_68a79b3012cc832e8778788b92ad8444