### PR TITLE
Refactor matches schema and add migration script

### DIFF
--- a/db.js
+++ b/db.js
@@ -56,18 +56,51 @@ ensureTable(
   'ea_last_matches'
 );
 
-// Recent match history fetched from EA API. One row per match per club.
+// Clubs catalog
+ensureTable(
+  `
+  CREATE TABLE IF NOT EXISTS clubs (
+    club_id   TEXT PRIMARY KEY,
+    club_name TEXT NOT NULL
+  )
+`,
+  'clubs'
+);
+
+// Matches: one row per match
 ensureTable(
   `
   CREATE TABLE IF NOT EXISTS matches (
-    id BIGINT PRIMARY KEY,
-    club_id BIGINT NOT NULL,
-    timestamp BIGINT NOT NULL,
-    data JSONB NOT NULL,
-    created_at TIMESTAMPTZ DEFAULT now()
+    match_id  TEXT  PRIMARY KEY,
+    ts_ms     BIGINT NOT NULL,
+    raw       JSONB  NOT NULL
   )
 `,
   'matches'
+);
+
+// Participants: two rows per match (home/away)
+ensureTable(
+  `
+  CREATE TABLE IF NOT EXISTS match_participants (
+    match_id  TEXT   NOT NULL REFERENCES matches(match_id) ON DELETE CASCADE,
+    club_id   TEXT   NOT NULL REFERENCES clubs(club_id),
+    is_home   BOOLEAN NOT NULL,
+    goals     INT     NOT NULL DEFAULT 0,
+    PRIMARY KEY (match_id, club_id)
+  )
+`,
+  'match_participants'
+);
+
+// Indexes
+ensureTable(
+  `CREATE INDEX IF NOT EXISTS idx_matches_ts_ms_desc ON matches (ts_ms DESC)`,
+  'idx_matches_ts_ms_desc'
+);
+ensureTable(
+  `CREATE INDEX IF NOT EXISTS idx_mp_club_ts ON match_participants (club_id, match_id)`,
+  'idx_mp_club_ts'
 );
 
 // Cached teams and players from EA API

--- a/public/teams.html
+++ b/public/teams.html
@@ -982,7 +982,7 @@ const fixturesPublicList = document.getElementById('fixturesPublicList');
 async function refreshMatches() {
   try {
     const res = await fetch('/api/matches');
-    const matches = await res.json();
+    const { matches } = await res.json();
     renderMatches(matches);
   } catch (err) {
     console.error('Failed to load matches', err);
@@ -997,13 +997,16 @@ function renderMatches(matches) {
     return;
   }
   matches.forEach(m => {
-    const teams = Object.values(m.clubs || {});
+    const teams = Object.values(m.clubs || {}).map(c => ({
+      name: c.details?.name || '',
+      score: c.goals
+    }));
     if (teams.length < 2) return;
     const card = document.createElement('div');
     card.className = 'match-card';
     card.innerHTML = `
       <div>${teams[0].name} ${teams[0].score} - ${teams[1].score} ${teams[1].name}</div>
-      <small>${new Date(m.timestamp * 1000).toLocaleString()}</small>
+      <small>${new Date(m.timestamp).toLocaleString()}</small>
     `;
     container.appendChild(card);
   });

--- a/scripts/fetchMatches.js
+++ b/scripts/fetchMatches.js
@@ -16,17 +16,40 @@ async function main() {
   for (const clubId of Object.keys(data || {})) {
     const matches = Array.isArray(data[clubId]) ? data[clubId] : [];
     for (const m of matches) {
-      const id = Number(m.matchId);
+      const matchId = String(m.matchId);
+      const tsMs = Number(m.timestamp) * 1000;
       try {
         const { rowCount } = await pool.query(
-          `INSERT INTO matches (id, club_id, timestamp, data)
-           VALUES ($1,$2,$3,$4)
-           ON CONFLICT (id) DO NOTHING`,
-          [id, Number(clubId), m.timestamp, m]
+          `INSERT INTO matches (match_id, ts_ms, raw)
+           VALUES ($1,$2,$3::jsonb)
+           ON CONFLICT (match_id) DO NOTHING`,
+          [matchId, tsMs, m]
         );
-        inserted += rowCount;
+        if (rowCount) {
+          const entries = Object.entries(m.clubs || {});
+          if (entries.length === 2) {
+            const homeEntry = entries.find(([, d]) => String(d?.home) === '1') || entries[0];
+            const awayEntry = entries.find(([id]) => id !== homeEntry[0]) || entries[1];
+            const [homeId, homeData] = homeEntry;
+            const [awayId, awayData] = awayEntry;
+            const homeGoals = Number(homeData?.score ?? homeData?.goals ?? 0);
+            const awayGoals = Number(awayData?.score ?? awayData?.goals ?? 0);
+            await pool.query(
+              `INSERT INTO match_participants (match_id, club_id, is_home, goals)
+               VALUES ($1,$2,TRUE,$3),($1,$4,FALSE,$5)
+               ON CONFLICT (match_id, club_id) DO NOTHING`,
+              [matchId, homeId, homeGoals, awayId, awayGoals]
+            );
+            await pool.query(
+              `INSERT INTO clubs (club_id, club_name) VALUES ($1,$2),($3,$4)
+               ON CONFLICT (club_id) DO NOTHING`,
+              [homeId, homeData?.name || '', awayId, awayData?.name || '']
+            );
+          }
+          inserted += rowCount;
+        }
       } catch (err) {
-        console.error('Failed to insert match', id, err);
+        console.error('Failed to insert match', matchId, err);
       }
     }
   }

--- a/test/matches.test.js
+++ b/test/matches.test.js
@@ -9,10 +9,12 @@ const queryStub = mock.method(pool, 'query', async sql => {
     return {
       rows: [
         {
-          id: '1',
-          club_id: '123',
-          timestamp: 123,
-          data: { matchId: '1', foo: 'bar' }
+          match_id: '1',
+          ts_ms: 1000,
+          clubs_obj: {
+            '1': { details: { name: 'A' }, goals: 1 },
+            '2': { details: { name: 'B' }, goals: 2 }
+          }
         }
       ]
     };
@@ -34,9 +36,20 @@ async function withServer(fn) {
 
 test('serves recent matches from db', async () => {
   await withServer(async port => {
-      const res = await fetch(`http://localhost:${port}/api/matches`);
-      const body = await res.json();
-      assert.deepStrictEqual(body, { matches: [{ matchId: '1', foo: 'bar' }] });
+    const res = await fetch(`http://localhost:${port}/api/matches`);
+    const body = await res.json();
+    assert.deepStrictEqual(body, {
+      matches: [
+        {
+          id: '1',
+          timestamp: 1000,
+          clubs: {
+            '1': { details: { name: 'A' }, goals: 1 },
+            '2': { details: { name: 'B' }, goals: 2 }
+          }
+        }
+      ]
     });
-    queryStub.mock.restore();
   });
+  queryStub.mock.restore();
+});


### PR DESCRIPTION
## Summary
- Introduce new clubs/matches/match_participants tables and indexes
- Add migration script to reshape matches table and seed club names
- Update match ingestion and API responses to use new schema and join participants
- Adjust frontend and tests for updated matches response

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a5a30a78832ea8a1989b4c3e72c2