### PR TITLE
Ensure database tables are initialized before server start

### DIFF
--- a/db.js
+++ b/db.js
@@ -17,118 +17,121 @@ function ensureTable(sql, name) {
     });
 }
 
-// Ensure fixtures table exists
-ensureTable(
-  `
-  CREATE TABLE IF NOT EXISTS fixtures (
-    id TEXT PRIMARY KEY,
-    home TEXT NOT NULL,
-    away TEXT NOT NULL,
-    score JSONB,
-    status TEXT,
-    details JSONB,
-    league_id TEXT,
-    played_at TIMESTAMPTZ
-  )
-`,
-  'fixtures'
-);
+async function initDb() {
+  // Ensure fixtures table exists
+  await ensureTable(
+    `
+    CREATE TABLE IF NOT EXISTS fixtures (
+      id TEXT PRIMARY KEY,
+      home TEXT NOT NULL,
+      away TEXT NOT NULL,
+      score JSONB,
+      status TEXT,
+      details JSONB,
+      league_id TEXT,
+      played_at TIMESTAMPTZ
+    )
+  `,
+    'fixtures'
+  );
 
-// Store league metadata (teams, etc.)
-ensureTable(
-  `
-  CREATE TABLE IF NOT EXISTS leagues (
-    id TEXT PRIMARY KEY,
-    details JSONB
-  )
-`,
-  'leagues'
-);
+  // Store league metadata (teams, etc.)
+  await ensureTable(
+    `
+    CREATE TABLE IF NOT EXISTS leagues (
+      id TEXT PRIMARY KEY,
+      details JSONB
+    )
+  `,
+    'leagues'
+  );
 
-// Track last fetched EA match per club
-ensureTable(
-  `
-  CREATE TABLE IF NOT EXISTS ea_last_matches (
-    club_id TEXT PRIMARY KEY,
-    last_match_id TEXT
-  )
-`,
-  'ea_last_matches'
-);
+  // Track last fetched EA match per club
+  await ensureTable(
+    `
+    CREATE TABLE IF NOT EXISTS ea_last_matches (
+      club_id TEXT PRIMARY KEY,
+      last_match_id TEXT
+    )
+  `,
+    'ea_last_matches'
+  );
 
-// Clubs catalog
-ensureTable(
-  `
-  CREATE TABLE IF NOT EXISTS clubs (
-    club_id   TEXT PRIMARY KEY,
-    club_name TEXT NOT NULL
-  )
-`,
-  'clubs'
-);
+  // Clubs catalog
+  await ensureTable(
+    `
+    CREATE TABLE IF NOT EXISTS clubs (
+      club_id   TEXT PRIMARY KEY,
+      club_name TEXT NOT NULL
+    )
+  `,
+    'clubs'
+  );
 
-// Matches: one row per match
-ensureTable(
-  `
-  CREATE TABLE IF NOT EXISTS matches (
-    match_id  TEXT  PRIMARY KEY,
-    ts_ms     BIGINT NOT NULL,
-    raw       JSONB  NOT NULL
-  )
-`,
-  'matches'
-);
+  // Matches: one row per match
+  await ensureTable(
+    `
+    CREATE TABLE IF NOT EXISTS matches (
+      match_id  TEXT  PRIMARY KEY,
+      ts_ms     BIGINT NOT NULL,
+      raw       JSONB  NOT NULL
+    )
+  `,
+    'matches'
+  );
 
-// Participants: two rows per match (home/away)
-ensureTable(
-  `
-  CREATE TABLE IF NOT EXISTS match_participants (
-    match_id  TEXT   NOT NULL REFERENCES matches(match_id) ON DELETE CASCADE,
-    club_id   TEXT   NOT NULL REFERENCES clubs(club_id),
-    is_home   BOOLEAN NOT NULL,
-    goals     INT     NOT NULL DEFAULT 0,
-    PRIMARY KEY (match_id, club_id)
-  )
-`,
-  'match_participants'
-);
+  // Participants: two rows per match (home/away)
+  await ensureTable(
+    `
+    CREATE TABLE IF NOT EXISTS match_participants (
+      match_id  TEXT   NOT NULL REFERENCES matches(match_id) ON DELETE CASCADE,
+      club_id   TEXT   NOT NULL REFERENCES clubs(club_id),
+      is_home   BOOLEAN NOT NULL,
+      goals     INT     NOT NULL DEFAULT 0,
+      PRIMARY KEY (match_id, club_id)
+    )
+  `,
+    'match_participants'
+  );
 
-// Indexes
-ensureTable(
-  `CREATE INDEX IF NOT EXISTS idx_matches_ts_ms_desc ON matches (ts_ms DESC)`,
-  'idx_matches_ts_ms_desc'
-);
-ensureTable(
-  `CREATE INDEX IF NOT EXISTS idx_mp_club_ts ON match_participants (club_id, match_id)`,
-  'idx_mp_club_ts'
-);
+  // Indexes
+  await ensureTable(
+    `CREATE INDEX IF NOT EXISTS idx_matches_ts_ms_desc ON matches (ts_ms DESC)`,
+    'idx_matches_ts_ms_desc'
+  );
+  await ensureTable(
+    `CREATE INDEX IF NOT EXISTS idx_mp_club_ts ON match_participants (club_id, match_id)`,
+    'idx_mp_club_ts'
+  );
 
-// Cached teams and players from EA API
-ensureTable(
-  `
-  CREATE TABLE IF NOT EXISTS teams (
-    id BIGINT PRIMARY KEY,
-    name TEXT,
-    logo JSONB,
-    season JSONB,
-    updated_at TIMESTAMPTZ DEFAULT now()
-  )
-`,
-  'teams'
-);
+  // Cached teams and players from EA API
+  await ensureTable(
+    `
+    CREATE TABLE IF NOT EXISTS teams (
+      id BIGINT PRIMARY KEY,
+      name TEXT,
+      logo JSONB,
+      season JSONB,
+      updated_at TIMESTAMPTZ DEFAULT now()
+    )
+  `,
+    'teams'
+  );
 
-ensureTable(
-  `
-  CREATE TABLE IF NOT EXISTS players (
-    id SERIAL PRIMARY KEY,
-    club_id BIGINT REFERENCES teams(id),
-    name TEXT,
-    position TEXT,
-    stats JSONB,
-    updated_at TIMESTAMPTZ DEFAULT now()
-  )
-`,
-  'players'
-);
+  await ensureTable(
+    `
+    CREATE TABLE IF NOT EXISTS players (
+      id SERIAL PRIMARY KEY,
+      club_id BIGINT REFERENCES teams(id),
+      name TEXT,
+      position TEXT,
+      stats JSONB,
+      updated_at TIMESTAMPTZ DEFAULT now()
+    )
+  `,
+    'players'
+  );
+}
 
 module.exports = pool;
+module.exports.initDb = initDb;

--- a/server.js
+++ b/server.js
@@ -410,20 +410,28 @@ if (process.env.NODE_ENV !== 'test') {
 }
 
 if (require.main === module) {
-  const PORT = process.env.PORT || 3001;
-  app.listen(PORT, () => {
-    console.log(`Server running on ${PORT}`);
-    if (process.env.NODE_ENV !== 'test') {
-      (async () => {
-        try {
-          await refreshAllMatches();
-          console.log(`[${new Date().toISOString()}] ✅ Initial sync complete.`);
-        } catch (err) {
-          console.error(`[${new Date().toISOString()}] ❌ Initial sync error:`, err.message);
+  (async () => {
+    try {
+      await pool.initDb();
+      const PORT = process.env.PORT || 3001;
+      app.listen(PORT, () => {
+        console.log(`Server running on ${PORT}`);
+        if (process.env.NODE_ENV !== 'test') {
+          (async () => {
+            try {
+              await refreshAllMatches();
+              console.log(`[${new Date().toISOString()}] ✅ Initial sync complete.`);
+            } catch (err) {
+              console.error(`[${new Date().toISOString()}] ❌ Initial sync error:`, err.message);
+            }
+          })();
         }
-      })();
+      });
+    } catch (err) {
+      console.error('Failed to initialize database', err);
+      process.exit(1);
     }
-  });
+  })();
 }
 
 module.exports = app;


### PR DESCRIPTION
## Summary
- add `initDb` in `db.js` to synchronously create required tables and indexes
- wait for `initDb` in server startup before listening for requests

## Testing
- `npm test` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68a7a8889df0832e844509cb91f12c82