### PR TITLE
Rename legacy match id before dropping club column

### DIFF
--- a/scripts/migrateMatchesSchema.js
+++ b/scripts/migrateMatchesSchema.js
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS matches (
   ts_ms     BIGINT NOT NULL,
   raw       JSONB  NOT NULL
 );
+ALTER TABLE matches RENAME COLUMN IF EXISTS id TO match_id;
 ALTER TABLE matches DROP COLUMN IF EXISTS club_id;
 CREATE TABLE IF NOT EXISTS match_participants (
   match_id  TEXT   NOT NULL REFERENCES matches(match_id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary
- Rename legacy `id` column to `match_id` during matches table migration
- Ensure `match_id` exists before removing `club_id`

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ad4fdfa0832e805bb3bdaa3c5ffd