### PR TITLE
Refine match ingestion mapping

### DIFF
--- a/scripts/fetchMatches.js
+++ b/scripts/fetchMatches.js
@@ -28,22 +28,22 @@ async function main() {
         if (rowCount) {
           const entries = Object.entries(m.clubs || {});
           if (entries.length === 2) {
-            const homeEntry = entries.find(([, d]) => String(d?.home) === '1') || entries[0];
-            const awayEntry = entries.find(([id]) => id !== homeEntry[0]) || entries[1];
-            const [homeId, homeData] = homeEntry;
-            const [awayId, awayData] = awayEntry;
-            const homeGoals = Number(homeData?.score ?? homeData?.goals ?? 0);
-            const awayGoals = Number(awayData?.score ?? awayData?.goals ?? 0);
+            const [[idA, clubA], [idB, clubB]] = entries;
+            const homeId = BigInt(idA) < BigInt(idB) ? idA : idB;
+            const [homeData, awayData] = homeId === idA ? [clubA, clubB] : [clubB, clubA];
+            const awayId = homeId === idA ? idB : idA;
+            const homeGoals = parseInt(homeData?.goals ?? homeData?.score ?? '0', 10);
+            const awayGoals = parseInt(awayData?.goals ?? awayData?.score ?? '0', 10);
             await pool.query(
               `INSERT INTO public.match_participants (match_id, club_id, is_home, goals)
                VALUES ($1,$2,TRUE,$3),($1,$4,FALSE,$5)
-               ON CONFLICT (match_id, club_id) DO NOTHING`,
+               ON CONFLICT (match_id, club_id) DO UPDATE SET goals = EXCLUDED.goals`,
               [matchId, homeId, homeGoals, awayId, awayGoals]
             );
             await pool.query(
               `INSERT INTO public.clubs (club_id, club_name) VALUES ($1,$2),($3,$4)
                ON CONFLICT (club_id) DO UPDATE SET club_name = EXCLUDED.club_name`,
-              [homeId, homeData?.name || '', awayId, awayData?.name || '']
+              [idA, clubA?.details?.name || '', idB, clubB?.details?.name || '']
             );
           }
           inserted += rowCount;


### PR DESCRIPTION
## Summary
- Determine home club by smaller club ID and upsert match participants with goal updates
- Persist club names from `details.name`

## Testing
- `npm test` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68a7c83b05d4832ea71a2eaabe53fa1e