### PR TITLE
Use UPCL data database and robust migrations

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,22 +1,13 @@
 // db.js
 const { Pool } = require('pg');
 
-// Use internal connection string (no SSL required inside Render)
-const pool = new Pool({
-  connectionString:
-    process.env.DATABASE_URL ||
-    "postgresql://upcl_user:2wMTWrulMhUoAYk5Z9lUpgaYYZobJYGf@dpg-d2hslce3jp1c738nvgg0-a/upcl",
-});
-
-// Ensure we default to the public schema
-pool.on('connect', c => c.query('SET search_path TO public'));
-
-async function initDb() {
-  if (process.env.DISABLE_INITDB === '1') {
-    console.log('[initDb] disabled (using migrations)');
-    return;
-  }
-  // legacy init removed
+const connStr = process.env.DATABASE_URL;
+if (!connStr) {
+  throw new Error('DATABASE_URL not set');
 }
 
-module.exports = { pool, initDb };
+// Ensure we default to the public schema
+const pool = new Pool({ connectionString: connStr });
+pool.on('connect', c => c.query('SET search_path TO public'));
+
+module.exports = { pool };

--- a/migrations/2025-08-21_ea_last_matches.sql
+++ b/migrations/2025-08-21_ea_last_matches.sql
@@ -1,0 +1,29 @@
+-- Rename legacy table with spaces and ensure structure
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'ea last matches'
+  ) THEN
+    EXECUTE 'ALTER TABLE "ea last matches" RENAME TO ea_last_matches';
+  END IF;
+END$$;
+
+-- Ensure table exists with proper columns
+CREATE TABLE IF NOT EXISTS public.ea_last_matches (
+  club_id TEXT PRIMARY KEY,
+  last_match_id TEXT
+);
+
+-- Add PK if missing
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.ea_last_matches'::regclass
+      AND contype = 'p'
+  ) THEN
+    ALTER TABLE public.ea_last_matches
+      ADD CONSTRAINT ea_last_matches_pkey PRIMARY KEY (club_id);
+  END IF;
+END$$;

--- a/migrations/2025-08-21_fix_matches.sql
+++ b/migrations/2025-08-21_fix_matches.sql
@@ -21,11 +21,18 @@ ALTER TABLE public.matches DROP COLUMN IF EXISTS club_id;
 CREATE TABLE IF NOT EXISTS public.match_participants (
   match_id  TEXT   NOT NULL REFERENCES public.matches(match_id) ON DELETE CASCADE,
   club_id   TEXT   NOT NULL REFERENCES public.clubs(club_id),
-  is_home   BOOLEAN NOT NULL,
-  goals     INT     NOT NULL DEFAULT 0,
+  is_home   BOOLEAN,
+  goals     INT,
   PRIMARY KEY (match_id, club_id)
 );
 
+-- Ensure nullable columns with no defaults
+ALTER TABLE public.match_participants
+  ALTER COLUMN is_home DROP NOT NULL,
+  ALTER COLUMN goals DROP NOT NULL,
+  ALTER COLUMN goals DROP DEFAULT;
+
 -- Indexes
-CREATE INDEX IF NOT EXISTS idx_matches_ts_ms_desc ON public.matches (ts_ms DESC);
+DROP INDEX IF EXISTS idx_matches_ts_ms_desc;
+CREATE INDEX IF NOT EXISTS idx_matches_ts_ms ON public.matches (ts_ms DESC);
 CREATE INDEX IF NOT EXISTS idx_mp_club_ts        ON public.match_participants (club_id, match_id);


### PR DESCRIPTION
## Summary
- connect using `DATABASE_URL` only and log active database on boot
- rename legacy `ea last matches` table and align schema for matches and participants
- improve migration runner to avoid nested transactions and insert matches with upserts

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden fetching deps)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d13c4afc832e816c52e0676b20b4