### PR TITLE
feat: add player card system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+
+# Card frame images
+public/assets/cards/*.png

--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ server, for example:
 ```bash
 LOG_LEVEL=debug node server.js
 ```
+
+## Card Assets
+
+Place card frame PNGs in `public/assets/cards/` with the following names:
+- `iron_rookie.png`
+- `steel_card.png`
+- `crimson_card.png`
+- `obsidian_elite.png`
+
+These files are ignored in git and must be supplied manually.

--- a/migrations/2025-08-22_players_table.sql
+++ b/migrations/2025-08-22_players_table.sql
@@ -1,0 +1,8 @@
+-- Create players table to cache player attributes from matches
+CREATE TABLE IF NOT EXISTS public.players (
+  player_id TEXT PRIMARY KEY,
+  club_id   TEXT NOT NULL,
+  name      TEXT,
+  position  TEXT,
+  vproattr  TEXT
+);

--- a/public/player-cards.html
+++ b/public/player-cards.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Player Cards</title>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet" />
+<style>
+.player-card {
+  position: relative;
+  width: 260px;
+  height: 370px;
+  margin: 10px;
+}
+
+.player-card .card-frame {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 12px;
+}
+
+.player-card .card-overlay {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 12px;
+  color: #fff;
+  text-shadow: 0 0 6px black;
+}
+
+.player-overall {
+  font-size: 32px;
+  font-weight: 900;
+}
+
+.player-name {
+  font-size: 18px;
+  font-weight: bold;
+}
+
+.player-position {
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.player-stats {
+  font-size: 14px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2px;
+  text-align: left;
+}
+</style>
+</head>
+<body>
+<div id="cards" style="display:flex;flex-wrap:wrap;"></div>
+<script>
+async function load() {
+  const res = await fetch('/api/player-cards');
+  const data = await res.json();
+  const container = document.getElementById('cards');
+  data.players.forEach(p => {
+    const card = document.createElement('div');
+    card.className = `player-card ${p.className}`;
+    card.innerHTML = `
+      <img src="/assets/cards/${p.frame}" class="card-frame" />
+      <div class="card-overlay">
+        <div class="player-overall">${p.stats.ovr}</div>
+        <div class="player-name">${p.name || ''}</div>
+        <div class="player-position">${p.position || ''}</div>
+        <div class="player-stats">
+          <span>PAC ${p.stats.pac}</span>
+          <span>SHO ${p.stats.sho}</span>
+          <span>PAS ${p.stats.pas}</span>
+          <span>DRI ${p.stats.dri}</span>
+          <span>DEF ${p.stats.def}</span>
+          <span>PHY ${p.stats.phy}</span>
+        </div>
+      </div>
+    `;
+    container.appendChild(card);
+  });
+}
+load();
+</script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -24,6 +24,7 @@ const eaApi = require('./services/eaApi');
 const { q } = require('./services/pgwrap');
 const { runMigrations } = require('./services/migrate');
 const { isNumericId } = require('./utils');
+const { parseVpro, tierFromStats } = require('./services/playerCards');
 
 // SQL statements for saving EA matches
 const SQL_INSERT_MATCH = `
@@ -43,6 +44,15 @@ const SQL_UPSERT_PARTICIPANT = `
   VALUES ($1, $2, $3, $4)
   ON CONFLICT (match_id, club_id) DO UPDATE
   SET is_home = EXCLUDED.is_home, goals = EXCLUDED.goals
+`;
+
+const SQL_UPSERT_PLAYER = `
+  INSERT INTO public.players (player_id, club_id, name, position, vproattr)
+  VALUES ($1, $2, $3, $4, $5)
+  ON CONFLICT (player_id) DO UPDATE
+    SET vproattr = EXCLUDED.vproattr,
+        position = EXCLUDED.position,
+        name = EXCLUDED.name;
 `;
 
 // Help node:test mocks that intercept global.fetch in environments without real modules
@@ -171,18 +181,32 @@ async function fetchClubMatches(clubId) {
   }
 }
 
-async function saveEaMatch(match) {
+async function saveEaMatch(match, clubId) {
   const matchId = String(match.matchId);
   const tsMs = Number(match.timestamp) * 1000;
   await q(SQL_INSERT_MATCH, [matchId, tsMs, match]);
 
   const clubs = match.clubs || {};
-  for (const clubId of Object.keys(clubs)) {
-    const c = clubs[clubId];
-    const name = c?.details?.name || `Club ${clubId}`;
+  for (const cid of Object.keys(clubs)) {
+    const c = clubs[cid];
+    const name = c?.details?.name || `Club ${cid}`;
     const goals = Number(c?.goals || 0);
-    await q(SQL_UPSERT_CLUB, [clubId, name]);
-    await q(SQL_UPSERT_PARTICIPANT, [matchId, clubId, null, goals]);
+    await q(SQL_UPSERT_CLUB, [cid, name]);
+    await q(SQL_UPSERT_PARTICIPANT, [matchId, cid, null, goals]);
+  }
+
+  if (clubId && match.players) {
+    for (const [playerId, p] of Object.entries(match.players)) {
+      const pClub = String(p?.clubId || p?.club_id || '');
+      if (pClub && pClub !== String(clubId)) continue;
+      await q(SQL_UPSERT_PLAYER, [
+        playerId,
+        String(clubId),
+        p?.name,
+        p?.preferredPosition,
+        p?.vproattr
+      ]);
+    }
   }
 }
 
@@ -190,7 +214,7 @@ async function refreshClubMatches(clubId) {
   const matches = await fetchClubMatches(clubId);
   for (const m of matches) {
     try {
-      await saveEaMatch(m);
+      await saveEaMatch(m, clubId);
     } catch (err) {
       logger.error({ err }, `[EA] Failed inserting match ${m.matchId} for club ${clubId}`);
     }
@@ -418,6 +442,46 @@ app.get('/api/players', async (req, res) => {
   const payload = { byClub, union, clubIds };
   _playersCache = { at: Date.now(), data: payload };
   res.json(payload);
+});
+
+app.get('/api/player-cards', async (_req, res) => {
+  const sql = `SELECT p.player_id, p.club_id, p.name, p.position, p.vproattr,
+                      COUNT(m.match_id) AS matches,
+                      SUM((m.raw->'players'->p.player_id->>'goals')::int) AS goals,
+                      SUM((m.raw->'players'->p.player_id->>'assists')::int) AS assists
+               FROM public.players p
+               LEFT JOIN public.matches m ON m.raw->'players' ? p.player_id
+               GROUP BY p.player_id, p.club_id, p.name, p.position, p.vproattr`;
+  const { rows } = await q(sql);
+  const players = rows.map(r => ({
+    playerId: r.player_id,
+    clubId: r.club_id,
+    name: r.name,
+    position: r.position,
+    vproattr: r.vproattr,
+    matches: Number(r.matches) || 0,
+    goals: Number(r.goals) || 0,
+    assists: Number(r.assists) || 0,
+    stats: parseVpro(r.vproattr)
+  }));
+
+  const sorted = players.slice().sort((a, b) => b.stats.ovr - a.stats.ovr);
+  const topCount = Math.max(1, Math.floor(players.length * 0.05));
+  const threshold = sorted[topCount - 1] ? sorted[topCount - 1].stats.ovr : Infinity;
+
+  for (const p of players) {
+    const t = tierFromStats({
+      ovr: p.stats.ovr,
+      matches: p.matches,
+      goals: p.goals,
+      assists: p.assists
+    }, threshold);
+    p.tier = t.tier;
+    p.frame = t.frame;
+    p.className = t.className;
+  }
+
+  res.json({ players });
 });
 
 // Auto update every 10 minutes

--- a/services/playerCards.js
+++ b/services/playerCards.js
@@ -1,0 +1,38 @@
+function parseVpro(vproattr = '') {
+  const parts = String(vproattr).split('|').map(n => parseInt(n, 10));
+  const avg = arr => Math.round(arr.reduce((a, b) => a + b, 0) / arr.length);
+  if (parts.length < 26) {
+    return { pac: 0, sho: 0, pas: 0, dri: 0, def: 0, phy: 0, ovr: 0 };
+  }
+  const pac = avg([parts[0], parts[1]]);
+  const sho = avg([parts[4], parts[5], parts[6]]);
+  const pas = avg([parts[9], parts[10], parts[12]]);
+  const dri = avg([parts[2], parts[7], parts[8]]);
+  const def = avg([parts[19], parts[20]]);
+  const phy = avg([parts[23], parts[24], parts[25]]);
+  const ovr = Math.round(
+    pac * 0.2 +
+    sho * 0.2 +
+    pas * 0.2 +
+    dri * 0.2 +
+    def * 0.1 +
+    phy * 0.1
+  );
+  return { pac, sho, pas, dri, def, phy, ovr };
+}
+
+function tierFromStats({ ovr, matches = 0, goals = 0, assists = 0 }, topOvrThreshold = Infinity) {
+  const ga = Number(goals) + Number(assists);
+  if (ovr >= topOvrThreshold) {
+    return { tier: 'obsidian', frame: 'obsidian_elite.png', className: 'tier-obsidian' };
+  }
+  if (matches < 5 || ovr < 70) {
+    return { tier: 'iron', frame: 'iron_rookie.png', className: 'tier-iron' };
+  }
+  if (ovr >= 85 && ga > 10) {
+    return { tier: 'crimson', frame: 'crimson_card.png', className: 'tier-crimson' };
+  }
+  return { tier: 'steel', frame: 'steel_card.png', className: 'tier-steel' };
+}
+
+module.exports = { parseVpro, tierFromStats };

--- a/test/playerCards.test.js
+++ b/test/playerCards.test.js
@@ -1,0 +1,24 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const { parseVpro, tierFromStats } = require('../services/playerCards');
+
+test('parseVpro computes stats and overall', () => {
+  const attrs = '091|094|094|089|072|084|064|095|066|093|064|089|091|094|082|095|083|079|068|089|091|069|091|082|067|065|075|090|077|010|010|010|010|010';
+  const stats = parseVpro(attrs);
+  assert.deepStrictEqual(stats, {
+    pac: 93,
+    sho: 73,
+    pas: 83,
+    dri: 85,
+    def: 90,
+    phy: 71,
+    ovr: 83
+  });
+});
+
+test('tierFromStats maps to expected tiers', () => {
+  assert.strictEqual(tierFromStats({ ovr: 60, matches: 2 }).tier, 'iron');
+  assert.strictEqual(tierFromStats({ ovr: 80, matches: 10 }).tier, 'steel');
+  assert.strictEqual(tierFromStats({ ovr: 88, matches: 12, goals: 6, assists: 6 }).tier, 'crimson');
+  assert.strictEqual(tierFromStats({ ovr: 99 }, 90).tier, 'obsidian');
+});


### PR DESCRIPTION
## Summary
- cache player attributes in a new `players` table
- compute card stats and tiers from `vproattr`
- expose `/api/player-cards` and front-end card rendering
- remove binary card frame assets and document manual placement

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cors)*
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68a839b3d9a4832e93a9f306a38158a5