### PR TITLE
Handle missing player names

### DIFF
--- a/server.js
+++ b/server.js
@@ -48,18 +48,12 @@ const SQL_UPSERT_PARTICIPANT = `
 
 const SQL_UPSERT_PLAYER = `
   INSERT INTO public.players (player_id, club_id, name, position, vproattr)
-  VALUES ($1, $2, $3, $4, $5)
+  VALUES ($1, $2, COALESCE($3, 'Unknown Player'), $4, $5)
   ON CONFLICT (player_id) DO UPDATE
-
-    SET club_id = EXCLUDED.club_id,
-        name = COALESCE(EXCLUDED.name, players.name),
+    SET name     = COALESCE(EXCLUDED.name, players.name),
         position = COALESCE(EXCLUDED.position, players.position),
-        vproattr = COALESCE(EXCLUDED.vproattr, players.vproattr);
-
-    SET vproattr = EXCLUDED.vproattr,
-        position = EXCLUDED.position,
-        name = EXCLUDED.name;
-
+        vproattr = COALESCE(EXCLUDED.vproattr, players.vproattr),
+        club_id  = EXCLUDED.club_id
 `;
 
 // Help node:test mocks that intercept global.fetch in environments without real modules
@@ -207,22 +201,16 @@ async function saveEaMatch(match, clubId) {
       const pClub = String(p?.clubId || p?.club_id || '');
       if (pClub && pClub !== String(clubId)) continue;
 
-      const name = p?.name || `Unknown_${playerId}`;
+      const name = p?.name || `Player ${playerId}`;
       const position = p?.preferredPosition || 'UNK';
       const vproattr = p?.vproattr || null;
+
       await q(SQL_UPSERT_PLAYER, [
         playerId,
         String(clubId),
         name,
         position,
         vproattr
-
-      await q(SQL_UPSERT_PLAYER, [
-        playerId,
-        String(clubId),
-        p?.name,
-        p?.preferredPosition,
-        p?.vproattr
       ]);
     }
   }


### PR DESCRIPTION
## Summary
- prevent NULL player names by defaulting to `Player {id}`
- upsert players using COALESCE so NULL values don't overwrite existing data

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68a8e45cbf80832ebc219a8beb97b1db