### PR TITLE
Default vproattr to empty JSONB

### DIFF
--- a/migrations/2025-08-22_players_table.sql
+++ b/migrations/2025-08-22_players_table.sql
@@ -4,5 +4,5 @@ CREATE TABLE IF NOT EXISTS public.players (
   club_id   TEXT NOT NULL,
   name      TEXT,
   position  TEXT,
-  vproattr  TEXT
+  vproattr  JSONB NOT NULL DEFAULT '{}'::jsonb
 );

--- a/server.js
+++ b/server.js
@@ -48,7 +48,7 @@ const SQL_UPSERT_PARTICIPANT = `
 
 const SQL_UPSERT_PLAYER = `
   INSERT INTO public.players (player_id, club_id, name, position, vproattr)
-  VALUES ($1, $2, COALESCE($3, 'Unknown Player'), $4, $5)
+  VALUES ($1, $2, COALESCE($3, 'Unknown Player'), $4, COALESCE($5, '{}'::jsonb))
   ON CONFLICT (player_id) DO UPDATE
     SET name     = COALESCE(EXCLUDED.name, players.name),
         position = COALESCE(EXCLUDED.position, players.position),


### PR DESCRIPTION
## Summary
- ensure players.vproattr column uses JSONB with a default empty object
- avoid null inserts by coalescing vproattr to '{}' in player upsert

## Testing
- `npm test` *(fails: Cannot find module 'express', 'pg')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e5bd1cd0832e98af756f87f21406