### PR TITLE
Avoid creating extra player grids

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -889,14 +889,9 @@ async function loadPlayers(){
 const oldList = card.querySelector('.player-list');
 if (oldList) oldList.remove();
 
-let grid = card.querySelector('.players-grid');
-if (!grid) {
-  grid = document.createElement('div');
-  grid.className = 'players-grid';
-  card.appendChild(grid);
-} else {
-  grid.innerHTML = '';
-}
+const grid = card.querySelector('.players-grid');
+if (!grid) return;
+grid.innerHTML = '';
 
       const members = playersByClub[clubId] || [];
       members.forEach(p=>{


### PR DESCRIPTION
## Summary
- Use pre-existing players-grid container for each team card to prevent player cards from rendering outside

## Testing
- `npm test` *(fails: MODULE_NOT_FOUND in db.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f2c43520832e9fa601691bb7dc38