### PR TITLE
Refine squad expansion to use players grid

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -883,12 +883,13 @@ async function loadPlayers(){
     playersByClub = d.byClub || {};
     document.querySelectorAll('.team-card').forEach(card=>{
       const clubId = card.getAttribute('data-club-id');
-const oldList = card.querySelector('.player-list');
-if (oldList) oldList.remove();
-
-const grid = card.querySelector('.players-grid');
-if (!grid) return;
-grid.innerHTML = '';
+      let grid = card.querySelector('.players-grid');
+      if (!grid){
+        grid = document.createElement('div');
+        grid.className = 'players-grid';
+        card.appendChild(grid);
+      }
+      grid.innerHTML = '';
 
       const members = playersByClub[clubId] || [];
       members.forEach(p=>{


### PR DESCRIPTION
## Summary
- build `.players-grid` container on demand when loading team squads
- populate player cards only within the grid and clear previous entries

## Testing
- `npm test` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68a8fb5ef94c832ea4ae97773e798970