### PR TITLE
Refine squad expansion to use players grid

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -72,6 +72,8 @@ h2{margin:0 0 10px}
 .team-meta{width:100%;display:flex;align-items:center;justify-content:space-between;margin-top:10px;gap:8px}
 .team-meta .name{font-weight:800;font-size:17px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .team-meta .record{font-weight:700;font-size:14px}
+.team-squad{display:none;width:100%}
+.team-card.expanded .team-squad{display:block}
 .players-grid {
   display: flex;
   flex-wrap: wrap;
@@ -222,112 +224,112 @@ h2{margin:0 0 10px}
       <div class="team-card" data-club-id="2491998" role="listitem">
         <img class="team-logo" src="/assets/logos/royal-republic-logo.png" alt="Royal Republic logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Royal%20Republic';" />
         <div class="team-meta"><div class="name">Royal Republic</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="1527486" role="listitem">
         <img class="team-logo" src="/assets/logos/gungan-fc.png" alt="Gungan FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Gungan%20FC';" />
         <div class="team-meta"><div class="name">Gungan FC</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="1969494" role="listitem">
         <img class="team-logo" src="/assets/logos/club-frijol.png" alt="Club Frijol logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Club%20Frijol';" />
         <div class="team-meta"><div class="name">Club Frijol</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="2086022" role="listitem">
         <img class="team-logo" src="/assets/logos/brehemen.png" alt="Brehemen logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Brehemen';" />
         <div class="team-meta"><div class="name">Brehemen</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="2462194" role="listitem">
         <img class="team-logo" src="/assets/logos/costa-chica-fc.png" alt="Costa Chica FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Costa%20Chica%20FC';" />
         <div class="team-meta"><div class="name">Costa Chica FC</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="5098824" role="listitem">
         <img class="team-logo" src="/assets/logos/sporting-de-la-ma.png" alt="Sporting de la ma logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Sporting%20de%20la%20ma';" />
         <div class="team-meta"><div class="name">Sporting de la ma</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="4869810" role="listitem">
         <img class="team-logo" src="/assets/logos/afc-tekki.png" alt="Afc Tekki logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Afc%20Tekki';" />
         <div class="team-meta"><div class="name">Afc Tekki</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="576007" role="listitem">
         <img class="team-logo" src="/assets/logos/ethabella-fc.png" alt="Ethabella FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Ethabella%20FC';" />
         <div class="team-meta"><div class="name">Ethabella FC</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="4933507" role="listitem">
         <img class="team-logo" src="/assets/logos/loss-toyz.png" alt="Loss Toyz logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Loss%20Toyz';" />
         <div class="team-meta"><div class="name">Loss Toyz</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="4824736" role="listitem">
         <img class="team-logo" src="/assets/logos/goldengoals-fc.png" alt="GoldenGoals FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=GoldenGoals%20FC';" />
         <div class="team-meta"><div class="name">GoldenGoals FC</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="481847" role="listitem">
         <img class="team-logo" src="/assets/logos/rooney-tunes.png" alt="Rooney tunes logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Rooney%20tunes';" />
         <div class="team-meta"><div class="name">Rooney tunes</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="3050467" role="listitem">
         <img class="team-logo" src="/assets/logos/invincible-afc.png" alt="invincible afc logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=invincible%20afc';" />
         <div class="team-meta"><div class="name">invincible afc</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="4154835" role="listitem">
         <img class="team-logo" src="/assets/logos/khalch-fc.png" alt="khalch Fc logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=khalch%20Fc';" />
         <div class="team-meta"><div class="name">khalch Fc</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="3638105" role="listitem">
         <img class="team-logo" src="/assets/logos/real-mvc.png" alt="Real mvc logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Real%20mvc';" />
         <div class="team-meta"><div class="name">Real mvc</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="55408" role="listitem">
         <img class="team-logo" src="/assets/logos/elite-vt.png" alt="Elite VT logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Elite%20VT';" />
         <div class="team-meta"><div class="name">Elite VT</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="4819681" role="listitem">
         <img class="team-logo" src="/assets/logos/everything-dead.png" alt="EVERYTHING DEAD logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=EVERYTHING%20DEAD';" />
         <div class="team-meta"><div class="name">EVERYTHING DEAD</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="35642" role="listitem">
         <img class="team-logo" src="/assets/logos/ebk-fc.png" alt="EBK FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=EBK%20FC';" />
         <div class="team-meta"><div class="name">EBK FC</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="afc-warriors" role="listitem">
         <img class="team-logo" src="/assets/logos/afc-warriors.png" alt="AFC Warriors logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=AFC%20Warriors';" />
         <div class="team-meta"><div class="name">AFC Warriors</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="jids-trivela" role="listitem">
         <img class="team-logo" src="/assets/logos/jids-trivela.png" alt="Jids Trivela logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Jids%20Trivela';" />
         <div class="team-meta"><div class="name">Jids Trivela</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="razorblack-fc" role="listitem">
         <img class="team-logo" src="/assets/logos/razorblack-fc.png" alt="Razorblack FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Razorblack%20FC';" />
         <div class="team-meta"><div class="name">Razorblack FC</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="fc-dhizz" role="listitem">
         <img class="team-logo" src="/assets/logos/fc-dhizz.png" alt="FC Dhizz logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=FC%20Dhizz';" />
         <div class="team-meta"><div class="name">FC Dhizz</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="elite-xi" role="listitem">
         <img class="team-logo" src="/assets/logos/elite-xi.png" alt="Elite xi logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Elite%20xi';" />
         <div class="team-meta"><div class="name">Elite xi</div><div class="record"></div></div>
-        <div class="players-grid"></div>
+        <div class="team-squad"><div class="players-grid"></div></div>
       </div>
     </div>
   </section>
@@ -679,8 +681,17 @@ function buildStaticTeams(){
     const id = card.getAttribute('data-club-id');
     const name = card.querySelector('.name').textContent.trim();
     const logo = card.querySelector('.team-logo').getAttribute('src');
+    let squad = card.querySelector('.team-squad');
+    if (!squad){
+      squad = document.createElement('div');
+      squad.className = 'team-squad';
+      card.appendChild(squad);
+    }
     const team = { id, name, logo };
-    card.addEventListener('click', () => showTeam(team));
+    card.addEventListener('click', async () => {
+      const expanded = card.classList.toggle('expanded');
+      if (expanded) await populateSquad(card, id);
+    });
     return team;
   });
   document.getElementById('teams-count').textContent = teams.length;
@@ -877,30 +888,40 @@ function tierFromOvr(ovr){
   return {frame:'obsidian_elite.png',className:'tier-obsidian'};
 }
 
-async function loadPlayers(){
-  try{
-    const d = await apiGet('/api/players');
-    playersByClub = d.byClub || {};
-    document.querySelectorAll('.team-card').forEach(card=>{
-      const clubId = card.getAttribute('data-club-id');
-const oldList = card.querySelector('.player-list');
-if (oldList) oldList.remove();
-
-const grid = card.querySelector('.players-grid');
-if (!grid) return;
-grid.innerHTML = '';
-
-      const members = playersByClub[clubId] || [];
-      members.forEach(p=>{
-        const nameRaw = p.name||p.playername||p.proName||p.personaName;
-        const name = nameRaw ? nameRaw : `Unknown_${p.playerId||p.playerid||''}`;
-        const pos = p.position||p.pos||'';
-        const stats = parseVpro(p.vproattr);
-        const t = tierFromOvr(stats?stats.ovr:null);
-        const s = stats || {pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:'??'};
-        const pc = document.createElement('div');
-        pc.className = `player-card ${t.className}`;
-        pc.innerHTML = `
+async function populateSquad(card, clubId){
+  let squad = card.querySelector('.team-squad');
+  if (!squad){
+    squad = document.createElement('div');
+    squad.className = 'team-squad';
+    card.appendChild(squad);
+  }
+  let grid = squad.querySelector('.players-grid');
+  if (!grid){
+    grid = document.createElement('div');
+    grid.className = 'players-grid';
+    squad.appendChild(grid);
+  }
+  const oldList = squad.querySelector('.player-list');
+  if (oldList) oldList.remove();
+  grid.innerHTML = '';
+  let members = playersByClub[clubId] || [];
+  if (!members.length && /^\d+$/.test(String(clubId))){
+    try{
+      const d = await apiGet(`/api/players?clubId=${encodeURIComponent(clubId)}`);
+      members = (d.byClub && d.byClub[clubId]) || [];
+      playersByClub[clubId] = members;
+    }catch{ members = []; }
+  }
+  members.forEach(p=>{
+    const nameRaw = p.name||p.playername||p.proName||p.personaName;
+    const name = nameRaw ? nameRaw : `Unknown_${p.playerId||p.playerid||''}`;
+    const pos = p.position||p.pos||'';
+    const stats = parseVpro(p.vproattr);
+    const t = tierFromOvr(stats?stats.ovr:null);
+    const s = stats || {pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:'??'};
+    const pc = document.createElement('div');
+    pc.className = `player-card ${t.className}`;
+    pc.innerHTML = `
           <img src="/assets/cards/${t.frame}" class="card-frame" />
           <div class="card-overlay">
             <div class="player-overall">${s.ovr}</div>
@@ -915,9 +936,14 @@ grid.innerHTML = '';
               <span>PHY ${s.phy}</span>
             </div>
           </div>`;
-        grid.appendChild(pc);
-      });
-    });
+    grid.appendChild(pc);
+  });
+}
+
+async function loadPlayers(){
+  try{
+    const d = await apiGet('/api/players');
+    playersByClub = d.byClub || {};
   }catch(e){
     console.error('Failed to load players', e);
   }


### PR DESCRIPTION
## Summary
- wrap team cards with a hidden `.team-squad` that reveals a `.players-grid` when expanded
- toggle squad expansion on card click and populate grid only inside the squad container
- clear previous lists before inserting FIFA-style player cards

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cors)*
- `npm test` *(fails: Cannot find module 'express', 'pg')*


------
https://chatgpt.com/codex/tasks/task_e_68a8fb5ef94c832ea4ae97773e798970