### PR TITLE
Implement collapsible team squad sections

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -72,8 +72,13 @@ h2{margin:0 0 10px}
 .team-meta{width:100%;display:flex;align-items:center;justify-content:space-between;margin-top:10px;gap:8px}
 .team-meta .name{font-weight:800;font-size:17px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .team-meta .record{font-weight:700;font-size:14px}
-.team-squad{display:none;width:100%}
-.team-card.expanded .team-squad{display:block}
+.team-squad{
+  width:100%;
+  margin-top:12px;
+  padding-top:10px;
+  border-top:1px solid #440000;
+  display:none;
+}
 .players-grid {
   display: flex;
   flex-wrap: wrap;
@@ -224,112 +229,112 @@ h2{margin:0 0 10px}
       <div class="team-card" data-club-id="2491998" role="listitem">
         <img class="team-logo" src="/assets/logos/royal-republic-logo.png" alt="Royal Republic logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Royal%20Republic';" />
         <div class="team-meta"><div class="name">Royal Republic</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="1527486" role="listitem">
         <img class="team-logo" src="/assets/logos/gungan-fc.png" alt="Gungan FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Gungan%20FC';" />
         <div class="team-meta"><div class="name">Gungan FC</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="1969494" role="listitem">
         <img class="team-logo" src="/assets/logos/club-frijol.png" alt="Club Frijol logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Club%20Frijol';" />
         <div class="team-meta"><div class="name">Club Frijol</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="2086022" role="listitem">
         <img class="team-logo" src="/assets/logos/brehemen.png" alt="Brehemen logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Brehemen';" />
         <div class="team-meta"><div class="name">Brehemen</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="2462194" role="listitem">
         <img class="team-logo" src="/assets/logos/costa-chica-fc.png" alt="Costa Chica FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Costa%20Chica%20FC';" />
         <div class="team-meta"><div class="name">Costa Chica FC</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="5098824" role="listitem">
         <img class="team-logo" src="/assets/logos/sporting-de-la-ma.png" alt="Sporting de la ma logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Sporting%20de%20la%20ma';" />
         <div class="team-meta"><div class="name">Sporting de la ma</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="4869810" role="listitem">
         <img class="team-logo" src="/assets/logos/afc-tekki.png" alt="Afc Tekki logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Afc%20Tekki';" />
         <div class="team-meta"><div class="name">Afc Tekki</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="576007" role="listitem">
         <img class="team-logo" src="/assets/logos/ethabella-fc.png" alt="Ethabella FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Ethabella%20FC';" />
         <div class="team-meta"><div class="name">Ethabella FC</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="4933507" role="listitem">
         <img class="team-logo" src="/assets/logos/loss-toyz.png" alt="Loss Toyz logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Loss%20Toyz';" />
         <div class="team-meta"><div class="name">Loss Toyz</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="4824736" role="listitem">
         <img class="team-logo" src="/assets/logos/goldengoals-fc.png" alt="GoldenGoals FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=GoldenGoals%20FC';" />
         <div class="team-meta"><div class="name">GoldenGoals FC</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="481847" role="listitem">
         <img class="team-logo" src="/assets/logos/rooney-tunes.png" alt="Rooney tunes logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Rooney%20tunes';" />
         <div class="team-meta"><div class="name">Rooney tunes</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="3050467" role="listitem">
         <img class="team-logo" src="/assets/logos/invincible-afc.png" alt="invincible afc logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=invincible%20afc';" />
         <div class="team-meta"><div class="name">invincible afc</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="4154835" role="listitem">
         <img class="team-logo" src="/assets/logos/khalch-fc.png" alt="khalch Fc logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=khalch%20Fc';" />
         <div class="team-meta"><div class="name">khalch Fc</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="3638105" role="listitem">
         <img class="team-logo" src="/assets/logos/real-mvc.png" alt="Real mvc logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Real%20mvc';" />
         <div class="team-meta"><div class="name">Real mvc</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="55408" role="listitem">
         <img class="team-logo" src="/assets/logos/elite-vt.png" alt="Elite VT logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Elite%20VT';" />
         <div class="team-meta"><div class="name">Elite VT</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="4819681" role="listitem">
         <img class="team-logo" src="/assets/logos/everything-dead.png" alt="EVERYTHING DEAD logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=EVERYTHING%20DEAD';" />
         <div class="team-meta"><div class="name">EVERYTHING DEAD</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="35642" role="listitem">
         <img class="team-logo" src="/assets/logos/ebk-fc.png" alt="EBK FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=EBK%20FC';" />
         <div class="team-meta"><div class="name">EBK FC</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="afc-warriors" role="listitem">
         <img class="team-logo" src="/assets/logos/afc-warriors.png" alt="AFC Warriors logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=AFC%20Warriors';" />
         <div class="team-meta"><div class="name">AFC Warriors</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="jids-trivela" role="listitem">
         <img class="team-logo" src="/assets/logos/jids-trivela.png" alt="Jids Trivela logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Jids%20Trivela';" />
         <div class="team-meta"><div class="name">Jids Trivela</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="razorblack-fc" role="listitem">
         <img class="team-logo" src="/assets/logos/razorblack-fc.png" alt="Razorblack FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Razorblack%20FC';" />
         <div class="team-meta"><div class="name">Razorblack FC</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="fc-dhizz" role="listitem">
         <img class="team-logo" src="/assets/logos/fc-dhizz.png" alt="FC Dhizz logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=FC%20Dhizz';" />
         <div class="team-meta"><div class="name">FC Dhizz</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
       <div class="team-card" data-club-id="elite-xi" role="listitem">
         <img class="team-logo" src="/assets/logos/elite-xi.png" alt="Elite xi logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Elite%20xi';" />
         <div class="team-meta"><div class="name">Elite xi</div><div class="record"></div></div>
-        <div class="team-squad"><div class="players-grid"></div></div>
+        <div class="team-squad" style="display:none"><div class="players-grid"></div></div>
       </div>
     </div>
   </section>
@@ -685,12 +690,26 @@ function buildStaticTeams(){
     if (!squad){
       squad = document.createElement('div');
       squad.className = 'team-squad';
+      squad.style.display = 'none';
+      squad.innerHTML = '<div class="players-grid"></div>';
       card.appendChild(squad);
     }
+    if (!squad.querySelector('.players-grid')){
+      const grid = document.createElement('div');
+      grid.className = 'players-grid';
+      squad.appendChild(grid);
+    }
     const team = { id, name, logo };
-    card.addEventListener('click', async () => {
-      const expanded = card.classList.toggle('expanded');
-      if (expanded) await populateSquad(card, id);
+    card.addEventListener('click', async (e) => {
+      if (e.target.closest('.player-card')) return;
+      const squad = card.querySelector('.team-squad');
+      const clubId = card.getAttribute('data-club-id');
+      if (squad.style.display === 'none' || !squad.style.display){
+        squad.style.display = 'block';
+        await populateSquad(card, clubId);
+      } else {
+        squad.style.display = 'none';
+      }
     });
     return team;
   });
@@ -889,12 +908,8 @@ function tierFromOvr(ovr){
 }
 
 async function populateSquad(card, clubId){
-  let squad = card.querySelector('.team-squad');
-  if (!squad){
-    squad = document.createElement('div');
-    squad.className = 'team-squad';
-    card.appendChild(squad);
-  }
+  const squad = card.querySelector('.team-squad');
+  if (!squad) return;
   let grid = squad.querySelector('.players-grid');
   if (!grid){
     grid = document.createElement('div');


### PR DESCRIPTION
## Summary
- Style and hide team squad sections within team cards
- Toggle squad visibility on card click without collapsing when a player card is clicked
- Ensure populateSquad fills players inside team-squad grid only

## Testing
- `npm test` *(fails: Cannot find module 'express', Cannot find module 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_68a9081407b8832e80f38963954cc1db