### PR TITLE
feat: store player attributes and serve players from db

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,9 @@
 
 ### `GET /api/players`
 
-Fetch players from EA Pro Clubs. You may pass one or more club IDs as a comma-separated
-`clubId`/`clubIds` query string. If omitted, the server falls back to the
-`LEAGUE_CLUB_IDS` environment variable or a built-in default list.
-
-The response shape is `{ members: [], byClub: { [clubId]: [] } }` where `members` is the
-deduplicated union list and `byClub` maps each club ID to its members. Results are cached
-for 60 seconds.
-
-#### Environment
-
-`LEAGUE_CLUB_IDS` – optional comma-separated club IDs overriding the built-in
-default list used when the route is called without specifying a `clubId`.
+Returns players stored in Postgres along with their most recent attributes.
+The response shape is `{ players: [...] }` where each player row contains
+`player_id`, `club_id`, `name`, `position`, `vproattr` and `last_seen`.
 
 ## Logging
 

--- a/migrations/2025-09-01_update_players_table.sql
+++ b/migrations/2025-09-01_update_players_table.sql
@@ -1,0 +1,11 @@
+-- Update players table to store latest attributes and tracking
+ALTER TABLE public.players
+  ALTER COLUMN club_id DROP NOT NULL,
+  ALTER COLUMN vproattr TYPE TEXT USING vproattr::text,
+  ALTER COLUMN vproattr DROP DEFAULT;
+
+UPDATE public.players SET name = 'Unknown Player' WHERE name IS NULL;
+ALTER TABLE public.players ALTER COLUMN name SET NOT NULL;
+
+ALTER TABLE public.players
+  ADD COLUMN IF NOT EXISTS last_seen TIMESTAMP DEFAULT now();

--- a/public/player-cards.html
+++ b/public/player-cards.html
@@ -87,19 +87,17 @@ function escapeHtml(str){
 async function load(){
   const res=await fetch('/api/players');
   const data=await res.json();
-  Object.entries(data.byClub||{}).forEach(([clubId,players])=>{
-    const grid=teamGrids[clubId];
+  (data.players||[]).forEach(p=>{
+    const grid=teamGrids[String(p.club_id)];
     if(!grid) return;
-    players.forEach(p=>{
-      const nameRaw=p.name||p.playername||p.proName||p.personaName;
-      const name=nameRaw?nameRaw:`Unknown_${p.playerId||p.playerid||''}`;
-      const pos=p.position||p.pos||'';
-      const stats=parseVpro(p.vproattr);
-      const t=tierFromOvr(stats?stats.ovr:null);
-      const s=stats||{pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:'??'};
-      const card=document.createElement('div');
-      card.className=`player-card ${t.className}`;
-      card.innerHTML=`
+    const name=p.name||`Unknown_${p.player_id||''}`;
+    const pos=p.position||'';
+    const stats=parseVpro(p.vproattr);
+    const t=tierFromOvr(stats?stats.ovr:null);
+    const s=stats||{pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:'??'};
+    const card=document.createElement('div');
+    card.className=`player-card ${t.className}`;
+    card.innerHTML=`
         <img src="/assets/cards/${t.frame}" class="card-frame" />
         <div class="card-overlay">
           <div class="player-overall">${s.ovr}</div>
@@ -114,8 +112,7 @@ async function load(){
             <span>PHY ${s.phy}</span>
           </div>
         </div>`;
-      grid.appendChild(card);
-    });
+    grid.appendChild(card);
   });
 }
 

--- a/public/teams.html
+++ b/public/teams.html
@@ -867,13 +867,6 @@ async function openTeamView(clubId){
   document.getElementById('teamBackBtn').addEventListener('click', closeTeamView);
   const grid = teamView.querySelector('.players-grid');
   let members = playersByClub[clubId] || [];
-  if (!members.length && /^\d+$/.test(String(clubId))){
-    try{
-      const d = await apiGet(`/api/players?clubId=${encodeURIComponent(clubId)}`);
-      members = (d.byClub && d.byClub[clubId]) || [];
-      playersByClub[clubId] = members;
-    }catch{ members = []; }
-  }
   members.forEach(p => {
     const stats = parseVpro(p.vproattr) || {pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:'??'};
     const t = tierFromOvr(stats.ovr);
@@ -906,7 +899,11 @@ function closeTeamView(){
 async function loadPlayers(){
   try{
     const d = await apiGet('/api/players');
-    playersByClub = d.byClub || {};
+    playersByClub = {};
+    (d.players||[]).forEach(p=>{
+      const cid=String(p.club_id);
+      (playersByClub[cid] ||= []).push(p);
+    });
   }catch(e){
     console.error('Failed to load players', e);
   }
@@ -971,11 +968,7 @@ async function loadSquad(clubId){
   document.getElementById('squadTools').style.display = 'none';
   try{
     let members = playersByClub[clubId] || [];
-    if (!members.length && /^\d+$/.test(String(clubId))){
-      const d = await apiGet(`/api/players?clubId=${encodeURIComponent(clubId)}`).catch(()=>({}));
-      members = (d.byClub && d.byClub[clubId]) || [];
-      playersByClub[clubId] = members;
-    } else if (!members.length){
+    if (!members.length){
       const r = await fetch(`/api/clubs/${encodeURIComponent(clubId)}/squad`, {credentials:'include'})
         .then(res => res.ok ? res.json() : { slots: [] })
         .catch(() => ({ slots: [] }));

--- a/test/players.test.js
+++ b/test/players.test.js
@@ -1,0 +1,35 @@
+const { test, mock } = require('node:test');
+const assert = require('assert');
+
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+
+const { pool } = require('../db');
+const queryStub = mock.method(pool, 'query', async sql => {
+  if (/SELECT \* FROM players/i.test(sql)) {
+    return { rows: [ { player_id: '1', club_id: '10', name: 'Test', position: 'ST', vproattr: '1|2', last_seen: '2020-01-01' } ] };
+  }
+  return { rows: [] };
+});
+
+const app = require('../server');
+
+async function withServer(fn) {
+  const server = app.listen(0);
+  try {
+    const port = server.address().port;
+    await fn(port);
+  } finally {
+    server.close();
+  }
+}
+
+test('serves players from database', async () => {
+  await withServer(async port => {
+    const res = await fetch(`http://localhost:${port}/api/players`);
+    const body = await res.json();
+    assert.deepStrictEqual(body, {
+      players: [ { player_id: '1', club_id: '10', name: 'Test', position: 'ST', vproattr: '1|2', last_seen: '2020-01-01' } ]
+    });
+  });
+  queryStub.mock.restore();
+});


### PR DESCRIPTION
## Summary
- upsert vpro attributes into players table and track last seen
- fetch players directly from postgres instead of EA API
- update frontend pages to parse player attributes and render cards per club

## Testing
- `npm install` *(fails: 403 Forbidden to registry)*
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68a90e28b76c832e8dbd0cc6caaa4860