### PR TITLE
Fix player card roster linking by club

### DIFF
--- a/migrations/2025-09-15_enforce_players_clubid.sql
+++ b/migrations/2025-09-15_enforce_players_clubid.sql
@@ -1,0 +1,3 @@
+-- Ensure club_id is not null
+ALTER TABLE public.players
+  ALTER COLUMN club_id SET NOT NULL;

--- a/public/player-cards.html
+++ b/public/player-cards.html
@@ -58,51 +58,28 @@ CLUBS.forEach(c=>{
   teamGrids[c.id]=card.querySelector('.players-grid');
 });
 
-function parseVpro(vproattr){
-  const parts=String(vproattr||'').split('|').map(n=>parseInt(n,10));
-  if(parts.length<26||parts.some(n=>isNaN(n))) return null;
-  const avg=a=>Math.round(a.reduce((x,y)=>x+y,0)/a.length);
-  const pac=avg([parts[0],parts[1]]);
-  const sho=avg([parts[4],parts[5],parts[6]]);
-  const pas=avg([parts[9],parts[10],parts[12]]);
-  const dri=avg([parts[2],parts[7],parts[8]]);
-  const def=avg([parts[19],parts[20]]);
-  const phy=avg([parts[23],parts[24],parts[25]]);
-  const ovr=Math.round(pac*0.2+sho*0.2+pas*0.2+dri*0.2+def*0.1+phy*0.1);
-  return {pac,sho,pas,dri,def,phy,ovr};
-}
-
-function tierFromOvr(ovr){
-  if(ovr==null) return {frame:'iron_rookie.png',className:'tier-iron'};
-  if(ovr<70) return {frame:'iron_rookie.png',className:'tier-iron'};
-  if(ovr<=84) return {frame:'steel_card.png',className:'tier-steel'};
-  if(ovr<=94) return {frame:'crimson_card.png',className:'tier-crimson'};
-  return {frame:'obsidian_elite.png',className:'tier-obsidian'};
-}
-
 function escapeHtml(str){
   return String(str||'').replace(/[&<>"']/g,s=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[s]));
 }
 
-async function load(){
-  const res=await fetch('/api/players');
-  const data=await res.json();
-  (data.players||[]).forEach(p=>{
-    const grid=teamGrids[String(p.club_id)];
-    if(!grid) return;
-    const name=p.name||`Unknown_${p.player_id||''}`;
-    const pos=p.position||'';
-    const stats=parseVpro(p.vproattr);
-    const t=tierFromOvr(stats?stats.ovr:null);
-    const s=stats||{pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:'??'};
-    const card=document.createElement('div');
-    card.className=`player-card ${t.className}`;
-    card.innerHTML=`
-        <img src="/assets/cards/${t.frame}" class="card-frame" />
+async function renderClub(c){
+  try{
+    const res=await fetch(`/api/clubs/${c.id}/player-cards`);
+    const data=await res.json();
+    (data.players||[]).forEach(p=>{
+      const grid=teamGrids[c.id];
+      const s=p.stats||{pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:'??'};
+      const frame=p.frame||'iron_rookie.png';
+      const cls=p.className||'tier-iron';
+      const card=document.createElement('div');
+      card.className=`player-card ${cls}`;
+      card.innerHTML=`
+        <img src="/assets/cards/${frame}" class="card-frame" />
         <div class="card-overlay">
           <div class="player-overall">${s.ovr}</div>
-          <div class="player-name">${escapeHtml(name)}</div>
-          <div class="player-position">${escapeHtml(pos)}</div>
+          <div class="player-name">${escapeHtml(p.name)}</div>
+          <div class="player-position">${escapeHtml(p.position||'')}
+          </div>
           <div class="player-stats">
             <span>PAC ${s.pac}</span>
             <span>SHO ${s.sho}</span>
@@ -112,11 +89,12 @@ async function load(){
             <span>PHY ${s.phy}</span>
           </div>
         </div>`;
-    grid.appendChild(card);
-  });
+      grid.appendChild(card);
+    });
+  }catch(e){console.error(e)}
 }
 
-load();
+CLUBS.forEach(renderClub);
 </script>
 </body>
 </html>

--- a/services/playerCards.js
+++ b/services/playerCards.js
@@ -21,18 +21,24 @@ function parseVpro(vproattr = '') {
   return { pac, sho, pas, dri, def, phy, ovr };
 }
 
-function tierFromStats({ ovr, matches = 0, goals = 0, assists = 0 }, topOvrThreshold = Infinity) {
-  const ga = Number(goals) + Number(assists);
-  if (ovr >= topOvrThreshold) {
-    return { tier: 'obsidian', frame: 'obsidian_elite.png', className: 'tier-obsidian' };
-  }
-  if (matches < 5 || ovr < 70) {
+function tierFromStats(
+  { ovr = 0, matches = 0, goals = 0, assists = 0, isCaptain = false },
+  topOvrThreshold = Infinity
+) {
+  if (!ovr || matches < 5) {
     return { tier: 'iron', frame: 'iron_rookie.png', className: 'tier-iron' };
   }
-  if (ovr >= 85 && ga > 10) {
+  if (isCaptain || ovr >= topOvrThreshold) {
+    return { tier: 'obsidian', frame: 'obsidian_elite.png', className: 'tier-obsidian' };
+  }
+  const ga = Number(goals) + Number(assists);
+  if (ga > 10) {
     return { tier: 'crimson', frame: 'crimson_card.png', className: 'tier-crimson' };
   }
-  return { tier: 'steel', frame: 'steel_card.png', className: 'tier-steel' };
+  if (matches >= 5) {
+    return { tier: 'steel', frame: 'steel_card.png', className: 'tier-steel' };
+  }
+  return { tier: 'iron', frame: 'iron_rookie.png', className: 'tier-iron' };
 }
 
 module.exports = { parseVpro, tierFromStats };

--- a/test/playerCards.test.js
+++ b/test/playerCards.test.js
@@ -34,5 +34,5 @@ test('tierFromStats maps to expected tiers', () => {
   assert.strictEqual(tierFromStats({ ovr: 60, matches: 2 }).tier, 'iron');
   assert.strictEqual(tierFromStats({ ovr: 80, matches: 10 }).tier, 'steel');
   assert.strictEqual(tierFromStats({ ovr: 88, matches: 12, goals: 6, assists: 6 }).tier, 'crimson');
-  assert.strictEqual(tierFromStats({ ovr: 99 }, 90).tier, 'obsidian');
+  assert.strictEqual(tierFromStats({ ovr: 99, matches: 20 }, 90).tier, 'obsidian');
 });

--- a/test/playerCardsApi.test.js
+++ b/test/playerCardsApi.test.js
@@ -1,0 +1,52 @@
+const { test, mock } = require('node:test');
+const assert = require('assert');
+
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+
+const eaApi = require('../services/eaApi');
+const { pool } = require('../db');
+const app = require('../server');
+
+const sampleVpro = '091|094|094|089|072|084|064|095|066|093|064|089|091|094|082|095|083|079|068|089|091|069|091|082|067|065';
+
+async function withServer(fn) {
+  const server = app.listen(0);
+  try {
+    const port = server.address().port;
+    await fn(port);
+  } finally {
+    server.close();
+  }
+}
+
+test('serves player cards for specific club', async () => {
+  const fetchStub = mock.method(eaApi, 'fetchPlayersForClubWithRetry', async () => ({
+    members: [
+      { name: 'Alice', gamesPlayed: '10', goals: '5', assists: '3', position: 'ST' },
+      { name: 'Bob', gamesPlayed: '2', goals: '1', assists: '0', position: 'GK' }
+    ]
+  }));
+
+  const queryStub = mock.method(pool, 'query', async (sql, params) => {
+    if (/FROM public\.players/i.test(sql)) {
+      return { rows: [{ player_id: '1', name: 'Alice', vproattr: sampleVpro }] };
+    }
+    return { rows: [] };
+  });
+
+  await withServer(async port => {
+    const res = await fetch(`http://localhost:${port}/api/clubs/10/player-cards`);
+    assert.strictEqual(res.status, 200);
+    const body = await res.json();
+    assert.strictEqual(body.players.length, 2);
+    const alice = body.players.find(p => p.name === 'Alice');
+    const bob = body.players.find(p => p.name === 'Bob');
+    assert(alice.stats && alice.stats.ovr > 0);
+    assert.strictEqual(alice.tier, 'obsidian');
+    assert.strictEqual(bob.stats, null);
+    assert.strictEqual(bob.tier, 'iron');
+  });
+
+  fetchStub.mock.restore();
+  queryStub.mock.restore();
+});


### PR DESCRIPTION
## Summary
- Use EA roster API per club and query cached attributes by player name
- Rework player tier logic and frontend to render cards with club-specific stats
- Add migration enforcing players.club_id NOT NULL and new endpoint tests

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `node --test test/playerCards.test.js`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a919bcb0c0832e8812a3c2fe5bde3b