### PR TITLE
Store player positions with fallback

### DIFF
--- a/migrations/2025-09-30_player_position_default.sql
+++ b/migrations/2025-09-30_player_position_default.sql
@@ -1,0 +1,5 @@
+-- Ensure player position defaults to 'UNK'
+ALTER TABLE public.players
+  ALTER COLUMN position SET DEFAULT 'UNK';
+
+UPDATE public.players SET position = 'UNK' WHERE position IS NULL;


### PR DESCRIPTION
## Summary
- Upsert players with position, falling back to `UNK` and preserving existing attributes
- Capture member positions when serving club player cards
- Add migration to default player position to `UNK`

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden for cors)*

------
https://chatgpt.com/codex/tasks/task_e_68a91f1dfbdc832e8bc1de96dc5aeae9