### PR TITLE
feat: enrich player cards with attribute lookup

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -849,9 +849,10 @@ function parseVpro(vproattr){
 
 function tierFromOvr(ovr){
   if(ovr==null) return {frame:'iron_rookie.png',className:'tier-iron'};
-  if(ovr<70) return {frame:'iron_rookie.png',className:'tier-iron'};
-  if(ovr<=84) return {frame:'steel_card.png',className:'tier-steel'};
-  if(ovr<=94) return {frame:'crimson_card.png',className:'tier-crimson'};
+  const n=Number(ovr)||0;
+  if(n<70) return {frame:'iron_rookie.png',className:'tier-iron'};
+  if(n<=84) return {frame:'steel_card.png',className:'tier-steel'};
+  if(n<=94) return {frame:'crimson_card.png',className:'tier-crimson'};
   return {frame:'obsidian_elite.png',className:'tier-obsidian'};
 }
 async function openTeamView(clubId){
@@ -866,27 +867,33 @@ async function openTeamView(clubId){
     <div class="players-grid"></div>`;
   document.getElementById('teamBackBtn').addEventListener('click', closeTeamView);
   const grid = teamView.querySelector('.players-grid');
-  let members = playersByClub[clubId] || [];
+  let members = [];
+  try{
+    const res = await fetch(`/api/teams/${clubId}/players`);
+    const data = await res.json();
+    members = data.players || [];
+  }catch(e){console.error(e);}
   members.forEach(p => {
-    const stats = parseVpro(p.vproattr) || {pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:'??'};
-    const t = tierFromOvr(stats.ovr);
-    grid.innerHTML += `
-      <div class="player-card ${t.className}">
-        <img src="/assets/cards/${t.frame}" class="card-frame" />
-        <div class="card-overlay">
-          <div class="player-overall">${stats.ovr}</div>
-          <div class="player-name">${escapeHtml(p.name||'Unknown')}</div>
-          <div class="player-position">${escapeHtml(p.position||'')}</div>
-          <div class="player-stats">
-            <span>PAC ${stats.pac}</span>
-            <span>SHO ${stats.sho}</span>
-            <span>PAS ${stats.pas}</span>
-            <span>DRI ${stats.dri}</span>
-            <span>DEF ${stats.def}</span>
-            <span>PHY ${stats.phy}</span>
-          </div>
+    const stats = p.stats || {pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:'??'};
+    const tier = tierFromOvr(stats.ovr);
+    const pc = document.createElement('div');
+    pc.className = `player-card ${tier.className}`;
+    pc.innerHTML = `
+      <img src="/assets/cards/${tier.frame}" class="card-frame" />
+      <div class="card-overlay">
+        <div class="player-overall">${stats.ovr}</div>
+        <div class="player-name">${escapeHtml(p.name||'Unknown')}</div>
+        <div class="player-position">${escapeHtml(p.position||'')}</div>
+        <div class="player-stats">
+          <span>PAC ${stats.pac}</span>
+          <span>SHO ${stats.sho}</span>
+          <span>PAS ${stats.pas}</span>
+          <span>DRI ${stats.dri}</span>
+          <span>DEF ${stats.def}</span>
+          <span>PHY ${stats.phy}</span>
         </div>
       </div>`;
+    grid.appendChild(pc);
   });
 }
 

--- a/services/playerAttributes.js
+++ b/services/playerAttributes.js
@@ -1,0 +1,25 @@
+const { pool } = require('../db');
+const { parseVpro } = require('./playerCards');
+
+async function getPlayerAttributes(playerId, clubId) {
+  const m = await pool.query(
+    `SELECT m.raw->'players'->$1->$2->>'vproattr' AS vproattr
+       FROM public.matches m
+       JOIN public.match_participants mp ON mp.match_id = m.match_id
+       WHERE mp.club_id = $1
+       ORDER BY m.ts_ms DESC
+       LIMIT 1`,
+    [clubId, playerId]
+  );
+  if (m.rows[0]?.vproattr) return parseVpro(m.rows[0].vproattr);
+
+  const p = await pool.query(
+    `SELECT vproattr FROM public.players WHERE player_id = $1 AND club_id = $2`,
+    [playerId, clubId]
+  );
+  if (p.rows[0]?.vproattr) return parseVpro(p.rows[0].vproattr);
+
+  return null;
+}
+
+module.exports = { getPlayerAttributes };

--- a/services/playerCards.js
+++ b/services/playerCards.js
@@ -21,6 +21,20 @@ function parseVpro(vproattr = '') {
   return { pac, sho, pas, dri, def, phy, ovr };
 }
 
+function tierFromOvr(ovr = 0) {
+  const n = Number(ovr) || 0;
+  if (n < 70) {
+    return { frame: 'iron_rookie.png', className: 'tier-iron' };
+  }
+  if (n <= 84) {
+    return { frame: 'steel_card.png', className: 'tier-steel' };
+  }
+  if (n <= 94) {
+    return { frame: 'crimson_card.png', className: 'tier-crimson' };
+  }
+  return { frame: 'obsidian_elite.png', className: 'tier-obsidian' };
+}
+
 function tierFromStats(
   { ovr = 0, matches = 0, goals = 0, assists = 0, isCaptain = false },
   topOvrThreshold = Infinity
@@ -41,4 +55,4 @@ function tierFromStats(
   return { tier: 'iron', frame: 'iron_rookie.png', className: 'tier-iron' };
 }
 
-module.exports = { parseVpro, tierFromStats };
+module.exports = { parseVpro, tierFromStats, tierFromOvr };

--- a/test/playerAttributes.test.js
+++ b/test/playerAttributes.test.js
@@ -1,0 +1,54 @@
+const { test, mock } = require('node:test');
+const assert = require('assert');
+
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+
+const { pool } = require('../db');
+const { getPlayerAttributes } = require('../services/playerAttributes');
+
+const sample = '1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26';
+
+function expectedOvr() {
+  const stats = { pac:2, sho:6, pas:11, dri:7, def:21, phy:25 }; // computed from sample
+  const ovr = Math.round(
+    stats.pac*0.2 + stats.sho*0.2 + stats.pas*0.2 +
+    stats.dri*0.2 + stats.def*0.1 + stats.phy*0.1
+  );
+  return ovr; // should be 10
+}
+
+const ovr10 = expectedOvr();
+
+test('getPlayerAttributes uses match data first', async () => {
+  const stub = mock.method(pool, 'query', async sql => {
+    if (/FROM public\.matches/i.test(sql)) {
+      return { rows: [{ vproattr: sample }] };
+    }
+    throw new Error('should not query players table');
+  });
+  const stats = await getPlayerAttributes('p1', 'c1');
+  assert.strictEqual(stats.ovr, ovr10);
+  stub.mock.restore();
+});
+
+test('getPlayerAttributes falls back to players table', async () => {
+  const stub = mock.method(pool, 'query', async sql => {
+    if (/FROM public\.matches/i.test(sql)) {
+      return { rows: [] };
+    }
+    if (/FROM public\.players/i.test(sql)) {
+      return { rows: [{ vproattr: sample }] };
+    }
+    return { rows: [] };
+  });
+  const stats = await getPlayerAttributes('p1', 'c1');
+  assert.strictEqual(stats.ovr, ovr10);
+  stub.mock.restore();
+});
+
+test('getPlayerAttributes returns null when missing', async () => {
+  const stub = mock.method(pool, 'query', async () => ({ rows: [] }));
+  const stats = await getPlayerAttributes('p1', 'c1');
+  assert.strictEqual(stats, null);
+  stub.mock.restore();
+});

--- a/test/teamPlayersApi.test.js
+++ b/test/teamPlayersApi.test.js
@@ -1,0 +1,45 @@
+const { test, mock } = require('node:test');
+const assert = require('assert');
+
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+
+const eaApi = require('../services/eaApi');
+const attrs = require('../services/playerAttributes');
+const app = require('../server');
+
+async function withServer(fn) {
+  const server = app.listen(0);
+  try {
+    const port = server.address().port;
+    await fn(port);
+  } finally {
+    server.close();
+  }
+}
+
+test('serves team players with attribute lookup', async () => {
+  const fetchStub = mock.method(eaApi, 'fetchPlayersForClubWithRetry', async () => ({
+    members: [
+      { playerId: '1', name: 'Alice', proPos: 'ST' },
+      { playerId: '2', name: 'Bob', proPos: 'GK' }
+    ]
+  }));
+  const attrStub = mock.method(attrs, 'getPlayerAttributes', async id => {
+    if (id === '1') return { pac:90, sho:80, pas:70, dri:85, def:40, phy:75, ovr:82 };
+    return null;
+  });
+
+  await withServer(async port => {
+    const res = await fetch(`http://localhost:${port}/api/teams/10/players`);
+    assert.strictEqual(res.status, 200);
+    const body = await res.json();
+    assert.strictEqual(body.players.length, 2);
+    const alice = body.players.find(p => p.playerId === '1');
+    const bob = body.players.find(p => p.playerId === '2');
+    assert(alice.stats && alice.stats.ovr === 82);
+    assert.strictEqual(bob.stats, null);
+  });
+
+  fetchStub.mock.restore();
+  attrStub.mock.restore();
+});


### PR DESCRIPTION
## Summary
- add tierFromOvr helper and expose new player attribute lookup
- implement /api/teams/:clubId/players using matches and players table fallbacks
- update team view to render cards with stats or placeholders

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden fetching cors)*

------
https://chatgpt.com/codex/tasks/task_e_68a928aadae4832ea6fe03e87733e037