### PR TITLE
Proxy team players through server

### DIFF
--- a/public/player-cards.html
+++ b/public/player-cards.html
@@ -125,13 +125,13 @@ async function upgradeClubPlayers(clubId){
     const d=await fetch(`/api/teams/${encodeURIComponent(clubId)}/players`).then(r=>r.json());
     const grid=document.querySelector(`.team-card[data-club-id="${clubId}"] .players-grid`);
     if(!grid) return;
-    (d.players||[]).forEach(p=>{
-      const id=p.playerId||p.player_id;
+    (d.members||[]).forEach(m=>{
+      const id=m.playerId||m.playerid;
       let card=grid.querySelector(`.player-card[data-player-id="${id}"]`);
       if(!card){
-        card=Array.from(grid.querySelectorAll('.player-card')).find(el=>el.dataset.playerName===p.name);
+        card=Array.from(grid.querySelectorAll('.player-card')).find(el=>el.dataset.playerName===m.name);
       }
-      const stats=p.stats||parseVpro(p.vproattr);
+      const stats=m.vproattr?parseVpro(m.vproattr):null;
       if(card&&stats) updatePlayerCard(card,stats);
     });
   }catch(e){

--- a/public/teams.html
+++ b/public/teams.html
@@ -871,10 +871,12 @@ async function openTeamView(clubId){
   try{
     const res = await fetch(`/api/teams/${clubId}/players`);
     const data = await res.json();
-    members = data.players || [];
-  }catch(e){console.error(e);}
-  members.forEach(p => {
-    const stats = p.stats || {pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:'??'};
+    members = data.members || [];
+  }catch(e){console.error(e);} 
+  members.forEach(m => {
+    const stats = m.vproattr
+      ? parseVpro(m.vproattr)
+      : { pac:'??', sho:'??', pas:'??', dri:'??', def:'??', phy:'??', ovr: m.proOverall || '??' };
     const tier = tierFromOvr(stats.ovr);
     const pc = document.createElement('div');
     pc.className = `player-card ${tier.className}`;
@@ -882,8 +884,8 @@ async function openTeamView(clubId){
       <img src="/assets/cards/${tier.frame}" class="card-frame" />
       <div class="card-overlay">
         <div class="player-overall">${stats.ovr}</div>
-        <div class="player-name">${escapeHtml(p.name||'Unknown')}</div>
-        <div class="player-position">${escapeHtml(p.position||'')}</div>
+        <div class="player-name">${escapeHtml(m.name||'Unknown')}</div>
+        <div class="player-position">${escapeHtml(m.proPos||'')}</div>
         <div class="player-stats">
           <span>PAC ${stats.pac}</span>
           <span>SHO ${stats.sho}</span>


### PR DESCRIPTION
## Summary
- proxy EA members stats via new `/api/teams/:clubId/players` endpoint
- adjust frontend to consume `/api/teams/:clubId/players` and map members to cards
- update tests to stub global fetch for team players API

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cors)*

------
https://chatgpt.com/codex/tasks/task_e_68a954a4c77c832e951769ed2cbae80a