### PR TITLE
Harden team player fetch endpoint

### DIFF
--- a/test/teamPlayersApi.test.js
+++ b/test/teamPlayersApi.test.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 
 process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
 
+const eaApi = require('../services/eaApi');
 const app = require('../server');
 
 async function withServer(fn) {
@@ -16,28 +17,34 @@ async function withServer(fn) {
 }
 
 test('proxies EA members stats', async () => {
-  const realFetch = global.fetch;
-  const fetchStub = mock.method(global, 'fetch', async (url, opts) => {
-    if (String(url).startsWith('https://proclubs.ea.com')) {
-      return {
-        ok: true,
-        json: async () => ({
-          members: [
-            { playerId: '1', name: 'Alice', proPos: 'ST', proOverall: 82 },
-            { playerId: '2', name: 'Bob', proPos: 'GK', proOverall: 70 }
-          ]
-        })
-      };
-    }
-    return realFetch(url, opts);
-  });
+  const fetchStub = mock.method(eaApi, 'fetchPlayersForClubWithRetry', async clubId => ({
+    members: [
+      { playerId: '1', name: 'Alice', proPos: 'ST', proOverall: 82 },
+      { playerId: '2', name: 'Bob', proPos: 'GK', proOverall: 70 }
+    ]
+  }));
 
   await withServer(async port => {
     const res = await fetch(`http://localhost:${port}/api/teams/10/players`);
     assert.strictEqual(res.status, 200);
     const body = await res.json();
     assert.strictEqual(body.members.length, 2);
-    assert(fetchStub.mock.calls.some(c => String(c.arguments[0]).includes('clubId=10')));
+    assert(fetchStub.mock.calls.some(c => c.arguments[0] === '10'));
+  });
+
+  fetchStub.mock.restore();
+});
+
+test('returns empty array if EA call fails', async () => {
+  const fetchStub = mock.method(eaApi, 'fetchPlayersForClubWithRetry', async () => {
+    throw new Error('EA down');
+  });
+
+  await withServer(async port => {
+    const res = await fetch(`http://localhost:${port}/api/teams/10/players`);
+    assert.strictEqual(res.status, 200);
+    const body = await res.json();
+    assert.deepStrictEqual(body, { members: [] });
   });
 
   fetchStub.mock.restore();


### PR DESCRIPTION
## Summary
- Use `eaApi.fetchPlayersForClubWithRetry` for `/api/teams/:clubId/players`
- Always return `{ members: [] }` on EA errors and log the failure
- Add tests for the endpoint and its fail-safe behavior

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cors)*

------
https://chatgpt.com/codex/tasks/task_e_68a95f246e60832e814546002e991d5d