### PR TITLE
Standardize club member fetch and API responses

### DIFF
--- a/services/eaApi.js
+++ b/services/eaApi.js
@@ -159,31 +159,14 @@ async function fetchClubMembers(clubId) {
 }
 
 async function fetchPlayersForClub(clubId) {
-  if (!clubId) throw new Error('clubId required');
-  const url =
-    `https://proclubs.ea.com/api/fc/clubs/${encodeURIComponent(
-      clubId
-    )}/members?platform=common-gen5`;
-  try {
-    const res = await eaFetch(url);
-    return res.json();
-  } catch (err) {
-    if (err.name === 'AbortError') {
-      throw { error: 'EA API request timed out' };
-    }
-    if (err.status) {
-      throw { error: 'EA API error', status: err.status };
-    }
-    if (err && err.error) throw err;
-    throw { error: 'EA API error' };
-  }
+  return fetchClubMembers(clubId);
 }
 
-async function fetchPlayersForClubWithRetry(clubId, retries = 2) {
+async function fetchClubMembersWithRetry(clubId, retries = 2) {
   let attempt = 0;
   while (true) {
     try {
-      return await module.exports.fetchPlayersForClub(clubId);
+      return await fetchClubMembers(clubId);
     } catch (err) {
       attempt++;
       if (attempt > retries) throw err;
@@ -191,6 +174,8 @@ async function fetchPlayersForClubWithRetry(clubId, retries = 2) {
     }
   }
 }
+
+const fetchPlayersForClubWithRetry = fetchClubMembersWithRetry;
 
 async function fetchClubInfo(clubId) {
   if (!clubId) throw new Error('clubId required');
@@ -232,6 +217,7 @@ module.exports = {
   fetchRecentLeagueMatches,
   fetchClubMembers,
   fetchPlayersForClub,
+  fetchClubMembersWithRetry,
   fetchPlayersForClubWithRetry,
   fetchClubInfo,
   fetchClubInfoWithRetry

--- a/test/eaMembers.test.js
+++ b/test/eaMembers.test.js
@@ -17,7 +17,7 @@ async function withServer(fn) {
 }
 
 test('normalizes array response', async () => {
-  const stub = mock.method(eaApi, 'fetchPlayersForClub', async () => [{ name: 'A' }]);
+  const stub = mock.method(eaApi, 'fetchClubMembersWithRetry', async () => [{ name: 'A' }]);
   await withServer(async port => {
     const res = await fetch(`http://localhost:${port}/api/ea/clubs/123/members`);
     const body = await res.json();
@@ -27,7 +27,11 @@ test('normalizes array response', async () => {
 });
 
 test('normalizes object map response', async () => {
-  const stub = mock.method(eaApi, 'fetchPlayersForClub', async () => ({ members: { a:{ name:'A'}, b:{ name:'B'} } }));
+  const stub = mock.method(
+    eaApi,
+    'fetchClubMembersWithRetry',
+    async () => ({ members: { a: { name: 'A' }, b: { name: 'B' } } })
+  );
   await withServer(async port => {
     const res = await fetch(`http://localhost:${port}/api/ea/clubs/123/members`);
     const body = await res.json();

--- a/test/playerCardsApi.test.js
+++ b/test/playerCardsApi.test.js
@@ -20,7 +20,7 @@ async function withServer(fn) {
 }
 
 test('serves player cards for specific club', async () => {
-  const fetchStub = mock.method(eaApi, 'fetchPlayersForClubWithRetry', async () => ({
+  const fetchStub = mock.method(eaApi, 'fetchClubMembersWithRetry', async () => ({
     members: [
       { name: 'Alice', gamesPlayed: '10', goals: '5', assists: '3', position: 'ST' },
       { name: 'Bob', gamesPlayed: '2', goals: '1', assists: '0', position: 'GK' }
@@ -38,9 +38,9 @@ test('serves player cards for specific club', async () => {
     const res = await fetch(`http://localhost:${port}/api/clubs/10/player-cards`);
     assert.strictEqual(res.status, 200);
     const body = await res.json();
-    assert.strictEqual(body.players.length, 2);
-    const alice = body.players.find(p => p.name === 'Alice');
-    const bob = body.players.find(p => p.name === 'Bob');
+    assert.strictEqual(body.members.length, 2);
+    const alice = body.members.find(p => p.name === 'Alice');
+    const bob = body.members.find(p => p.name === 'Bob');
     assert(alice.stats && alice.stats.ovr > 0);
     assert.strictEqual(alice.tier, 'obsidian');
     assert.strictEqual(bob.stats, null);

--- a/test/teamPlayersApi.test.js
+++ b/test/teamPlayersApi.test.js
@@ -17,7 +17,7 @@ async function withServer(fn) {
 }
 
 test('proxies EA members stats', async () => {
-  const fetchStub = mock.method(eaApi, 'fetchPlayersForClubWithRetry', async clubId => ({
+  const fetchStub = mock.method(eaApi, 'fetchClubMembersWithRetry', async clubId => ({
     members: [
       { playerId: '1', name: 'Alice', proPos: 'ST', proOverall: 82 },
       { playerId: '2', name: 'Bob', proPos: 'GK', proOverall: 70 }
@@ -36,7 +36,7 @@ test('proxies EA members stats', async () => {
 });
 
 test('returns empty array if EA call fails', async () => {
-  const fetchStub = mock.method(eaApi, 'fetchPlayersForClubWithRetry', async () => {
+  const fetchStub = mock.method(eaApi, 'fetchClubMembersWithRetry', async () => {
     throw new Error('EA down');
   });
 


### PR DESCRIPTION
## Summary
- Replace obsolete `fetchPlayersForClub` with `fetchClubMembers` and provide a retry wrapper.
- Update server endpoints to use the unified member fetcher and consistently return `{ members: [...] }`.
- Align player card endpoint and related tests with the new members-based response shape.

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden for registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68a96f379e68832ebba71ef538e4a809