### PR TITLE
feat: proxy club kits and render on cards

### DIFF
--- a/public/player-cards.html
+++ b/public/player-cards.html
@@ -70,6 +70,10 @@ async function getTeamId(clubId){
   return info?.teamId;
 }
 
+function getKitUrl(teamId){
+  return `https://proclubsdatabase.s3.us-east-2.amazonaws.com/minikits/j0_${teamId}_0.png`;
+}
+
 function applyGradient(img,customKit){
   const box=document.createElement('div');
   box.className='player-kit-box';
@@ -85,7 +89,7 @@ async function renderClubKits(clubId){
   try{info=await getClubInfo(clubId);}catch(e){info=null;}
   const teamId=info?.teamId;
   const customKit=info?.customKit||{};
-  const kitUrl=teamId?`https://proclubsdatabase.s3.us-east-2.amazonaws.com/minikits/j0_${teamId}_0.png`:null;
+  const kitUrl=teamId?getKitUrl(teamId):null;
   document.querySelectorAll(`.team-card[data-club-id="${clubId}"] .player-kit`).forEach(img=>{
     if(kitUrl){
       img.src=kitUrl;
@@ -196,9 +200,6 @@ async function loadPlayers(){
     });
     renderClubKits(clubId);
     upgradeClubPlayers(clubId);
-  });
-  document.querySelectorAll('.team-card').forEach(card=>{
-    renderClubKits(card.getAttribute('data-club-id'));
   });
 }
 

--- a/test/eaClubInfo.test.js
+++ b/test/eaClubInfo.test.js
@@ -27,11 +27,17 @@ test('fetches club info from EA', async () => {
 });
 
 test('fetches club info via backend proxy', async () => {
-  const stub = mock.method(eaApi, 'fetchClubInfoWithRetry', async () => ({ name: 'Club', customLogo: 'L' }));
   await withServer(async port => {
-    const res = await fetch(`http://localhost:${port}/api/club-info/123`);
+    const realFetch = global.fetch;
+    const stub = mock.method(global, 'fetch', async (url, opts) => {
+      if (String(url).includes('proclubs.ea.com')) {
+        return { json: async () => ({ '123': { name: 'Club', customLogo: 'L' } }) };
+      }
+      return realFetch(url, opts);
+    });
+    const res = await realFetch(`http://localhost:${port}/api/club-info/123`);
     const body = await res.json();
-    assert.deepStrictEqual(body, { club: { name: 'Club', customLogo: 'L' } });
+    assert.deepStrictEqual(body, { '123': { name: 'Club', customLogo: 'L' } });
+    stub.mock.restore();
   });
-  stub.mock.restore();
 });


### PR DESCRIPTION
## Summary
- proxy EA club-info endpoint through backend to bypass CORS
- load club kit images on player cards with gradient fallback
- test: stub fetch for club info proxy

## Testing
- `npm install` *(fails: 403 Forbidden retrieving cors)*
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68aae6b670cc832ea36dc766e5d765a9