### PR TITLE
Restrict player card rendering to team grids

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -851,8 +851,6 @@ document.getElementById('mgrSubmit').onclick = async ()=>{
 // =======================
 //   TEAMS LIST / DETAIL
 // =======================
-const teamsGrid = document.getElementById('teamsGrid');
-const teamsCount = document.getElementById('teams-count');
 const detailView = document.getElementById('detail-view');
 const detailTitle = document.getElementById('detail-title');
 const detailSub   = document.getElementById('detail-sub');
@@ -949,6 +947,15 @@ function buildPlayerCard(p, stats, tier){
   return card;
 }
 
+function appendPlayerCard(card, container){
+  const allowed = (
+    (container.classList.contains('players-grid') && container.closest('.team-card')) ||
+    (container.classList.contains('players-grid') && container.closest('#teamView')) ||
+    container.id === 'squadBody'
+  );
+  if(allowed) container.appendChild(card);
+}
+
 function updatePlayerCard(card, stats){
   const tier = tierFromOvr(stats.ovr);
   card.className = `player-card ${tier.className}`;
@@ -1003,7 +1010,7 @@ async function openTeamView(clubId){
       : { pac:'??', sho:'??', pas:'??', dri:'??', def:'??', phy:'??', ovr: m.proOverall || '??' };
     const tier = tierFromOvr(stats.ovr);
     const card = buildPlayerCard({ ...m, position: m.proPos }, stats, tier);
-    grid.appendChild(card);
+    appendPlayerCard(card, grid);
     renderClubKits(clubId);
   });
   renderClubKits(clubId);
@@ -1033,7 +1040,7 @@ async function loadPlayers(){
         const stats = parseVpro(p.vproattr);
         const tier = tierFromOvr(stats?stats.ovr:null);
         const el = buildPlayerCard(p, stats, tier);
-        grid.appendChild(el);
+        appendPlayerCard(el, grid);
         renderClubKits(clubId);
       });
       renderClubKits(clubId);
@@ -1124,7 +1131,7 @@ async function loadSquad(clubId){
       const t = tierFromOvr(stats?stats.ovr:null);
       const s = stats || {pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:'??'};
       const card = buildPlayerCard({ name, position: pos, playerId: p.playerId||p.playerid }, s, t);
-      body.appendChild(card);
+      appendPlayerCard(card, body);
       renderClubKits(clubId);
     });
     renderClubKits(clubId);


### PR DESCRIPTION
## Summary
- Add `appendPlayerCard` helper to ensure cards render only within approved grids
- Replace direct `appendChild` calls in team view, teams list, and squad editor with helper

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden fetching cors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7ebfaf08832eb71b88995b5834d9