### PR TITLE
Avoid duplicate kit requests in team views

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -1004,7 +1004,6 @@ async function openTeamView(clubId){
     const tier = tierFromOvr(stats.ovr);
     const card = buildPlayerCard({ ...m, position: m.proPos }, stats, tier);
     grid.appendChild(card);
-    renderClubKits(clubId);
   });
   renderClubKits(clubId);
 }
@@ -1034,7 +1033,6 @@ async function loadPlayers(){
         const tier = tierFromOvr(stats?stats.ovr:null);
         const el = buildPlayerCard(p, stats, tier);
         grid.appendChild(el);
-        renderClubKits(clubId);
       });
       renderClubKits(clubId);
       upgradeClubPlayers(clubId);


### PR DESCRIPTION
## Summary
- Render club kits once after listing players in team view and team cards to prevent duplicate API calls

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab83d7be24832e8c5f588278af65d8