### PR TITLE
Allow rendering club kits within specified root

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -906,13 +906,13 @@ function applyGradient(img, customKit){
   img.replaceWith(box);
 }
 
-async function renderClubKits(clubId){
+async function renderClubKits(clubId, root = document){
   let info=null;
   try{ info = await getClubInfo(clubId); }catch(e){ info=null; }
   const teamId = info?.teamId;
   const customKit = info?.customKit || {};
   const kitUrl = teamId ? getKitUrl(teamId) : null;
-  document.querySelectorAll(`[data-club-id="${clubId}"] .player-kit`).forEach(img=>{
+  root.querySelectorAll(`[data-club-id="${clubId}"] .player-kit`).forEach(img=>{
     if(kitUrl){
       img.src = kitUrl;
       img.onerror = () => applyGradient(img, customKit);
@@ -1013,7 +1013,7 @@ async function openTeamView(clubId){
     const card = buildPlayerCard({ ...m, position }, stats, tier);
     grid.appendChild(card);
   });
-  renderClubKits(clubId);
+  renderClubKits(clubId, teamView);
 }
 
 function closeTeamView(){


### PR DESCRIPTION
## Summary
- Let `renderClubKits` accept an optional root element and target selectors within it
- Pass the team view container when opening a team so kit updates stay scoped

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org/cors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab90d7dd20832e9ea60220b104f781