### PR TITLE
Merge stored attributes into player endpoints

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -964,7 +964,7 @@ function updatePlayerCard(card, stats){
 
 async function upgradeClubPlayers(clubId){
   try{
-    const d = await fetch(`/api/teams/${encodeURIComponent(clubId)}/players`).then(r=>r.json());
+    const d = await fetch(`/api/clubs/${encodeURIComponent(clubId)}/player-cards`).then(r=>r.json());
     const grid = document.querySelector(`.team-card[data-club-id="${clubId}"] .players-grid`);
     if(!grid) return;
     (d.members||[]).forEach(m=>{
@@ -973,8 +973,7 @@ async function upgradeClubPlayers(clubId){
       if(!card){
         card = Array.from(grid.querySelectorAll('.player-card')).find(el=>el.dataset.playerName === m.name);
       }
-      const stats = m.vproattr ? parseVpro(m.vproattr) : null;
-      if(card && stats) updatePlayerCard(card, stats);
+      if(card && m.stats) updatePlayerCard(card, m.stats);
     });
   }catch(e){
     console.error('upgrade failed', e);
@@ -995,22 +994,14 @@ async function openTeamView(clubId){
   const grid = teamView.querySelector('.players-grid');
   let members = [];
   try{
-    const res = await fetch(`/api/teams/${clubId}/players`);
+    const res = await fetch(`/api/clubs/${clubId}/player-cards`);
     const data = await res.json();
     members = data.members || [];
   }catch(e){console.error(e);}
-  const local = playersByClub[String(clubId)] || [];
   members.forEach(m => {
-    const id = String(m.playerId || m.player_id || m.playerid || '');
-    const match = local.find(p => String(p.playerId || p.player_id || p.playerid || '') === id);
-    const stats = match?.vproattr
-      ? parseVpro(match.vproattr)
-      : (m.vproattr
-        ? parseVpro(m.vproattr)
-        : { pac:'??', sho:'??', pas:'??', dri:'??', def:'??', phy:'??', ovr: match?.proOverall || m.proOverall || '??' });
-    const position = match?.position || match?.pos || m.proPos;
-    const tier = tierFromOvr(stats.ovr);
-    const card = buildPlayerCard({ ...m, position }, stats, tier);
+    const stats = m.stats || (m.vproattr ? parseVpro(m.vproattr) : {pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:m.proOverall||m.ovr||'??'});
+    const tier = { className: m.className, frame: m.frame };
+    const card = buildPlayerCard(m, stats, tier);
     grid.appendChild(card);
   });
   renderClubKits(clubId, teamView);
@@ -1024,27 +1015,29 @@ function closeTeamView(){
 
 async function loadPlayers(){
   try{
-    const d = await apiGet('/api/players');
     playersByClub = {};
-    (d.players||[]).forEach(p=>{
-      const cid = String(p.club_id);
-      (playersByClub[cid] ||= []).push(p);
-    });
-    document.querySelectorAll('.team-card').forEach(card=>{
+    const cards = document.querySelectorAll('.team-card');
+    await Promise.all(Array.from(cards).map(async card=>{
       const clubId = card.getAttribute('data-club-id');
-      const members = (d.players||[]).filter(p=>String(p.club_id)===clubId);
       const grid = card.querySelector('.players-grid');
       if(!grid) return;
-      grid.innerHTML='';
-      members.forEach(p=>{
-        const stats = parseVpro(p.vproattr);
-        const tier = tierFromOvr(stats?stats.ovr:null);
-        const el = buildPlayerCard(p, stats, tier);
-        grid.appendChild(el);
-      });
-      renderClubKits(clubId);
-      upgradeClubPlayers(clubId);
-    });
+      try{
+        const res = await fetch(`/api/clubs/${encodeURIComponent(clubId)}/player-cards`);
+        const data = await res.json();
+        const members = data.members || [];
+        playersByClub[clubId] = members;
+        grid.innerHTML='';
+        members.forEach(m=>{
+          const stats = m.stats || (m.vproattr ? parseVpro(m.vproattr) : {pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:m.proOverall||m.ovr||'??'});
+          const tier = { className: m.className, frame: m.frame };
+          const el = buildPlayerCard(m, stats, tier);
+          grid.appendChild(el);
+        });
+        renderClubKits(clubId);
+      }catch(e){
+        console.error('load club players failed', e);
+      }
+    }));
   }catch(e){
     console.error('Failed to load players', e);
   }

--- a/services/playerAttributes.js
+++ b/services/playerAttributes.js
@@ -14,8 +14,8 @@ async function getPlayerAttributes(playerId, clubId) {
   if (m.rows[0]?.vproattr) return parseVpro(m.rows[0].vproattr);
 
   const p = await pool.query(
-    `SELECT vproattr FROM public.players WHERE player_id = $1 AND club_id = $2`,
-    [playerId, clubId]
+    `SELECT vproattr FROM public.playercards WHERE player_id = $1`,
+    [playerId]
   );
   if (p.rows[0]?.vproattr) return parseVpro(p.rows[0].vproattr);
 

--- a/test/playerAttributes.test.js
+++ b/test/playerAttributes.test.js
@@ -31,12 +31,12 @@ test('getPlayerAttributes uses match data first', async () => {
   stub.mock.restore();
 });
 
-test('getPlayerAttributes falls back to players table', async () => {
+test('getPlayerAttributes falls back to playercards table', async () => {
   const stub = mock.method(pool, 'query', async sql => {
     if (/FROM public\.matches/i.test(sql)) {
       return { rows: [] };
     }
-    if (/FROM public\.players/i.test(sql)) {
+    if (/FROM public\.playercards/i.test(sql)) {
       return { rows: [{ vproattr: sample }] };
     }
     return { rows: [] };

--- a/test/playersUpsert.test.js
+++ b/test/playersUpsert.test.js
@@ -7,13 +7,12 @@ const { q } = require('../services/pgwrap');
 const { pool } = require('../db');
 
 const SQL_UPSERT_PLAYER = `
-  INSERT INTO public.players (player_id, club_id, name, position, vproattr, goals, assists, last_seen)
-  VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+  INSERT INTO public.players (player_id, club_id, name, position, goals, assists, last_seen)
+  VALUES ($1, $2, $3, $4, $5, $6, NOW())
   ON CONFLICT (player_id, club_id)
   DO UPDATE SET
     name = EXCLUDED.name,
     position = EXCLUDED.position,
-    vproattr = EXCLUDED.vproattr,
     goals = EXCLUDED.goals,
     assists = EXCLUDED.assists,
     last_seen = NOW();
@@ -29,17 +28,17 @@ test('upserts player per club without 42P10 and updates attributes', async () =>
         err.code = '42P10';
         throw err;
       }
-      const [pid, cid, name, position, vproattr, goals, assists] = params;
-      store.set(key, { pid, cid, name, position, vproattr, goals, assists });
+      const [pid, cid, name, position, goals, assists] = params;
+      store.set(key, { pid, cid, name, position, goals, assists });
     }
     return { rows: [] };
   });
 
-  await q(SQL_UPSERT_PLAYER, ['1', '10', 'Alice', 'ST', 'attr1', 1, 2]);
-  await q(SQL_UPSERT_PLAYER, ['1', '10', 'Alicia', 'CM', 'attr2', 3, 4]);
+  await q(SQL_UPSERT_PLAYER, ['1', '10', 'Alice', 'ST', 1, 2]);
+  await q(SQL_UPSERT_PLAYER, ['1', '10', 'Alicia', 'CM', 3, 4]);
 
   queryStub.mock.restore();
   const row = store.get('1:10');
   assert.strictEqual(row.name, 'Alicia');
-  assert.strictEqual(row.vproattr, 'attr2');
+  assert.strictEqual(row.goals, 3);
 });


### PR DESCRIPTION
## Summary
- Load and merge player attributes from `playercards` in `/api/teams/:clubId/players`
- Drop `vproattr` from `SQL_UPSERT_PLAYER` and align queries/tests
- Fetch player cards on the client to show stats and tiers

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ab937e4f3c832e80e4c9630d1596c3