### PR TITLE
Ensure players table stays updated with player card data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Player attribute snapshots are stored separately in a `playercards` table
 rendering cards, stats are loaded from `playercards` if available; otherwise the
 basic `players` row is used as a fallback with placeholder stats.
 
+The `/api/clubs/:clubId/player-cards` endpoint fetches club members from EA,
+merges any stored attributes, and updates the `players` table so aggregate
+queries via `GET /api/players` stay in sync.
+
 ## Logging
 
 This project uses a Pino-based logger. Logs default to the `info` level. To see

--- a/public/teams.html
+++ b/public/teams.html
@@ -1022,6 +1022,7 @@ async function loadPlayers(){
       const grid = card.querySelector('.players-grid');
       if(!grid) return;
       try{
+        // `/api/clubs/:id/player-cards` also refreshes the server's players table
         const res = await fetch(`/api/clubs/${encodeURIComponent(clubId)}/player-cards`);
         const data = await res.json();
         const members = data.members || [];

--- a/server.js
+++ b/server.js
@@ -517,17 +517,19 @@ app.get('/api/clubs/:clubId/player-cards', async (req, res) => {
     }
     const cardMap = new Map(cardRows.map(r => [r.player_id, r]));
 
-    for (const m of members) {
-      const id = m.playerId || m.playerid;
-      if (!id) continue;
-      const name = m.name || m.playername || 'Player_' + id;
-      const pos = m.position || m.pos || m.proPos || 'UNK';
-      const card = cardMap.get(String(id)) || {};
-      const vproattr = card.vproattr || null;
-      const goals = Number(m.goals || 0);
-      const assists = Number(m.assists || 0);
-      await q(SQL_UPSERT_PLAYER, [id, clubId, name, pos, goals, assists]);
-    }
+    await Promise.all(
+      members.map(async m => {
+        const id = m.playerId || m.playerid;
+        if (!id) return;
+        const name = m.name || m.playername || 'Player_' + id;
+        const pos = m.position || m.pos || m.proPos || 'UNK';
+        const card = cardMap.get(String(id)) || {};
+        const vproattr = card.vproattr || null;
+        const goals = Number(m.goals || 0);
+        const assists = Number(m.assists || 0);
+        await q(SQL_UPSERT_PLAYER, [id, clubId, name, pos, goals, assists]);
+      })
+    );
 
     const membersDetailed = members.map(m => {
       const id = m.playerId || m.playerid;

--- a/test/playerCardsApi.test.js
+++ b/test/playerCardsApi.test.js
@@ -27,12 +27,12 @@ test('serves player cards for specific club', async () => {
     ]
   }));
 
-    const queryStub = mock.method(pool, 'query', async (sql, params) => {
-      if (/FROM public\.playercards/i.test(sql)) {
-        return { rows: [{ player_id: '1', name: 'Alice', position: 'ST', vproattr: sampleVpro, ovr: 83 }] };
-      }
-      return { rows: [] };
-    });
+  const queryStub = mock.method(pool, 'query', async (sql, params) => {
+    if (/FROM public\.playercards/i.test(sql)) {
+      return { rows: [{ player_id: '1', name: 'Alice', position: 'ST', vproattr: sampleVpro, ovr: 83 }] };
+    }
+    return { rows: [] };
+  });
 
   await withServer(async port => {
     const res = await fetch(`http://localhost:${port}/api/clubs/10/player-cards`);
@@ -46,6 +46,9 @@ test('serves player cards for specific club', async () => {
     assert.strictEqual(bob.stats, null);
     assert.strictEqual(bob.tier, 'iron');
   });
+
+  const upsertCall = queryStub.mock.calls.find(c => /INSERT INTO public\.players/i.test(c.arguments[0]));
+  assert(upsertCall, 'players table should be upserted');
 
   fetchStub.mock.restore();
   queryStub.mock.restore();


### PR DESCRIPTION
## Summary
- Upsert club members into `players` in parallel when serving `/api/clubs/:clubId/player-cards`
- Document and test that the player-cards API refreshes the `players` table
- Note frontend expectation that fetching player cards also updates backend players data

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm test` (fails: Cannot find module 'express')

------
https://chatgpt.com/codex/tasks/task_e_68aba5ec2648832eaaf4251890c61b1c