### PR TITLE
Use players table for player card attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@ Returns the latest squad members stored in Postgres.
 The response shape is `{ players: [...] }` where each player row contains
 `player_id`, `club_id`, `name`, `position` and `last_seen`.
 
-Player attribute snapshots are stored separately in a `playercards` table
-(`player_id`, `name`, `position`, `vproattr`, `ovr`, `last_updated`). When
-rendering cards, stats are loaded from `playercards` if available; otherwise the
-basic `players` row is used as a fallback with placeholder stats.
+Player attribute snapshots are stored directly on the `players` table via the
+`vproattr` column. When rendering cards, stats are parsed from `players.vproattr`
+if available; otherwise a placeholder set is used.
+
+The `/api/clubs/:clubId/player-cards` endpoint fetches club members from EA,
+merges any stored attributes from `players`, and updates that table so aggregate
+queries via `GET /api/players` stay in sync.
 
 ## Logging
 

--- a/public/teams.html
+++ b/public/teams.html
@@ -1022,6 +1022,7 @@ async function loadPlayers(){
       const grid = card.querySelector('.players-grid');
       if(!grid) return;
       try{
+        // `/api/clubs/:id/player-cards` refreshes and reads from the server's players table
         const res = await fetch(`/api/clubs/${encodeURIComponent(clubId)}/player-cards`);
         const data = await res.json();
         const members = data.members || [];

--- a/server.js
+++ b/server.js
@@ -46,13 +46,14 @@ const SQL_UPSERT_PARTICIPANT = `
 `;
 
 const SQL_UPSERT_PLAYER = `
-  INSERT INTO public.players (player_id, club_id, name, position, goals, assists, last_seen)
-  VALUES ($1, $2, $3, $4, $5, $6, NOW())
+  INSERT INTO public.players (player_id, club_id, name, position, goals, assists, vproattr, last_seen)
+  VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
   ON CONFLICT (player_id, club_id) DO UPDATE SET
     name = EXCLUDED.name,
     position = EXCLUDED.position,
     goals = EXCLUDED.goals,
     assists = EXCLUDED.assists,
+    vproattr = EXCLUDED.vproattr,
     last_seen = NOW()
 `;
 
@@ -214,11 +215,11 @@ async function saveEaMatch(match) {
           pdata.proPos ||
           'UNK';
         const vproattr = pdata.vproattr || null;
+        const stats = vproattr ? parseVpro(vproattr) : null;
         const goals = Number(pdata.goals || 0);
         const assists = Number(pdata.assists || 0);
-        await q(SQL_UPSERT_PLAYER, [pid, cid, name, pos, goals, assists]);
+        await q(SQL_UPSERT_PLAYER, [pid, cid, name, pos, goals, assists, vproattr]);
         if (vproattr) {
-          const stats = parseVpro(vproattr);
           await q(SQL_UPSERT_PLAYERCARD, [pid, name, pos, vproattr, stats.ovr]);
         }
       }
@@ -462,8 +463,8 @@ app.get('/api/teams/:clubId/players', async (req, res) => {
     let cardRows = [];
     if (ids.length) {
       const { rows } = await q(
-        `SELECT player_id, position, vproattr, ovr FROM public.playercards WHERE player_id = ANY($1::text[])`,
-        [ids]
+        `SELECT player_id, position, vproattr FROM public.players WHERE player_id = ANY($1::text[]) AND club_id = $2`,
+        [ids, clubId]
       );
       cardRows = rows;
     }
@@ -475,8 +476,6 @@ app.get('/api/teams/:clubId/players', async (req, res) => {
       const merged = { ...m };
       if (card.position && !merged.position) merged.position = card.position;
       if (card.vproattr) merged.vproattr = card.vproattr;
-      if (!merged.ovr && card.ovr) merged.ovr = card.ovr;
-      if (!merged.proOverall && card.ovr) merged.proOverall = card.ovr;
       merged.stats = card.vproattr ? parseVpro(card.vproattr) : null;
       return merged;
     });
@@ -507,33 +506,32 @@ app.get('/api/clubs/:clubId/player-cards', async (req, res) => {
     }
 
     const ids = members.map(m => m.playerId || m.playerid).filter(Boolean);
-    let cardRows = [];
+    let playerRows = [];
     if (ids.length) {
       const { rows } = await q(
-        `SELECT player_id, name, position, vproattr, ovr FROM public.playercards WHERE player_id = ANY($1::text[])`,
-        [ids]
+        `SELECT player_id, vproattr FROM public.players WHERE player_id = ANY($1::text[]) AND club_id = $2`,
+        [ids, clubId]
       );
-      cardRows = rows;
+      playerRows = rows;
     }
-    const cardMap = new Map(cardRows.map(r => [r.player_id, r]));
+    const playerMap = new Map(playerRows.map(r => [r.player_id, r]));
 
+    const membersDetailed = [];
     for (const m of members) {
       const id = m.playerId || m.playerid;
       if (!id) continue;
       const name = m.name || m.playername || 'Player_' + id;
       const pos = m.position || m.pos || m.proPos || 'UNK';
-      const card = cardMap.get(String(id)) || {};
-      const vproattr = card.vproattr || null;
+      const existing = playerMap.get(String(id)) || {};
+      const vproattr = m.vproattr || existing.vproattr || null;
+      const stats = vproattr ? parseVpro(vproattr) : null;
       const goals = Number(m.goals || 0);
       const assists = Number(m.assists || 0);
-      await q(SQL_UPSERT_PLAYER, [id, clubId, name, pos, goals, assists]);
-    }
-
-    const membersDetailed = members.map(m => {
-      const id = m.playerId || m.playerid;
-      const card = cardMap.get(String(id)) || {};
-      const stats = card.vproattr ? parseVpro(card.vproattr) : null;
-      return {
+      await q(SQL_UPSERT_PLAYER, [id, clubId, name, pos, goals, assists, vproattr]);
+      if (vproattr) {
+        await q(SQL_UPSERT_PLAYERCARD, [id, name, pos, vproattr, stats.ovr]);
+      }
+      membersDetailed.push({
         playerId: id || null,
         clubId,
         name: m.name,
@@ -542,9 +540,10 @@ app.get('/api/clubs/:clubId/player-cards', async (req, res) => {
         goals: Number(m.goals) || 0,
         assists: Number(m.assists) || 0,
         isCaptain: m.isCaptain == 1 || m.captain == 1 || m.role === 'captain',
+        vproattr,
         stats,
-      };
-    });
+      });
+    }
 
     const withStats = membersDetailed.filter(p => p.stats && p.stats.ovr);
     const sorted = withStats.slice().sort((a, b) => b.stats.ovr - a.stats.ovr);

--- a/services/playerAttributes.js
+++ b/services/playerAttributes.js
@@ -14,8 +14,8 @@ async function getPlayerAttributes(playerId, clubId) {
   if (m.rows[0]?.vproattr) return parseVpro(m.rows[0].vproattr);
 
   const p = await pool.query(
-    `SELECT vproattr FROM public.playercards WHERE player_id = $1`,
-    [playerId]
+    `SELECT vproattr FROM public.players WHERE player_id = $1 AND club_id = $2`,
+    [playerId, clubId]
   );
   if (p.rows[0]?.vproattr) return parseVpro(p.rows[0].vproattr);
 

--- a/test/playerAttributes.test.js
+++ b/test/playerAttributes.test.js
@@ -31,12 +31,12 @@ test('getPlayerAttributes uses match data first', async () => {
   stub.mock.restore();
 });
 
-test('getPlayerAttributes falls back to playercards table', async () => {
+test('getPlayerAttributes falls back to players table', async () => {
   const stub = mock.method(pool, 'query', async sql => {
     if (/FROM public\.matches/i.test(sql)) {
       return { rows: [] };
     }
-    if (/FROM public\.playercards/i.test(sql)) {
+    if (/FROM public\.players/i.test(sql)) {
       return { rows: [{ vproattr: sample }] };
     }
     return { rows: [] };

--- a/test/playerCardsApi.test.js
+++ b/test/playerCardsApi.test.js
@@ -27,12 +27,12 @@ test('serves player cards for specific club', async () => {
     ]
   }));
 
-    const queryStub = mock.method(pool, 'query', async (sql, params) => {
-      if (/FROM public\.playercards/i.test(sql)) {
-        return { rows: [{ player_id: '1', name: 'Alice', position: 'ST', vproattr: sampleVpro, ovr: 83 }] };
-      }
-      return { rows: [] };
-    });
+  const queryStub = mock.method(pool, 'query', async (sql, params) => {
+    if (/FROM public\.players/i.test(sql)) {
+      return { rows: [{ player_id: '1', vproattr: sampleVpro }] };
+    }
+    return { rows: [] };
+  });
 
   await withServer(async port => {
     const res = await fetch(`http://localhost:${port}/api/clubs/10/player-cards`);
@@ -46,6 +46,10 @@ test('serves player cards for specific club', async () => {
     assert.strictEqual(bob.stats, null);
     assert.strictEqual(bob.tier, 'iron');
   });
+
+  const upsertCall = queryStub.mock.calls.find(c => /INSERT INTO public\.players/i.test(c.arguments[0]));
+  assert(upsertCall, 'players table should be upserted');
+  assert.strictEqual(upsertCall.arguments[1][6], sampleVpro);
 
   fetchStub.mock.restore();
   queryStub.mock.restore();


### PR DESCRIPTION
## Summary
- pull player card attributes from `players` instead of `playercards`
- store `vproattr` on upsert to keep `players` cache in sync
- adjust attribute service, docs, and tests for `players`-based lookup

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm test` (fails: Cannot find module 'express')

------
https://chatgpt.com/codex/tasks/task_e_68aba5ec2648832eaaf4251890c61b1c