### PR TITLE
Refactor team player loading and club info caching

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -881,10 +881,14 @@ function tierFromOvr(ovr){
   return {frame:'obsidian_elite.png',className:'tier-obsidian'};
 }
 
+const clubInfoCache = new Map();
 async function getClubInfo(clubId){
+  if(clubInfoCache.has(clubId)) return clubInfoCache.get(clubId);
   const res = await fetch(`/api/club-info/${encodeURIComponent(clubId)}`);
   const data = await res.json();
-  return data && data[clubId];
+  const info = data?.club || data[clubId];
+  if(info) clubInfoCache.set(clubId, info);
+  return info;
 }
 
 async function getTeamId(clubId){
@@ -992,15 +996,10 @@ async function openTeamView(clubId){
   teamView.dataset.clubId = clubId;
   document.getElementById('teamBackBtn').addEventListener('click', closeTeamView);
   const grid = teamView.querySelector('.players-grid');
-  let members = [];
-  try{
-    const res = await fetch(`/api/clubs/${clubId}/player-cards`);
-    const data = await res.json();
-    members = data.members || [];
-  }catch(e){console.error(e);}
+  const members = playersByClub[clubId] || [];
   members.forEach(m => {
-    const stats = m.stats || (m.vproattr ? parseVpro(m.vproattr) : {pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:m.proOverall||m.ovr||'??'});
-    const tier = { className: m.className, frame: m.frame };
+    const stats = parseVpro(m.vproattr) || {pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:'??'};
+    const tier = tierFromOvr(stats?.ovr);
     const card = buildPlayerCard(m, stats, tier);
     grid.appendChild(card);
   });
@@ -1016,30 +1015,30 @@ function closeTeamView(){
 async function loadPlayers(){
   try{
     playersByClub = {};
+    const res = await fetch('/api/players');
+    const data = await res.json();
+    const players = data.players || [];
+    players.forEach(p => {
+      const cid = String(p.club_id || p.clubId || '');
+      if(!cid) return;
+      if(!playersByClub[cid]) playersByClub[cid] = [];
+      playersByClub[cid].push(p);
+    });
+
     const cards = document.querySelectorAll('.team-card');
-    await Promise.all(Array.from(cards).map(async card=>{
+    cards.forEach(card => {
       const clubId = card.getAttribute('data-club-id');
       const grid = card.querySelector('.players-grid');
       if(!grid) return;
-      try{
-        // `/api/clubs/:id/player-cards` refreshes and reads from the server's players table
-
-        const res = await fetch(`/api/clubs/${encodeURIComponent(clubId)}/player-cards`);
-        const data = await res.json();
-        const members = data.members || [];
-        playersByClub[clubId] = members;
-        grid.innerHTML='';
-        members.forEach(m=>{
-          const stats = m.stats || (m.vproattr ? parseVpro(m.vproattr) : {pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:m.proOverall||m.ovr||'??'});
-          const tier = { className: m.className, frame: m.frame };
-          const el = buildPlayerCard(m, stats, tier);
-          grid.appendChild(el);
-        });
-        renderClubKits(clubId);
-      }catch(e){
-        console.error('load club players failed', e);
-      }
-    }));
+      grid.innerHTML='';
+      (playersByClub[clubId]||[]).forEach(m => {
+        const stats = parseVpro(m.vproattr) || {pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:'??'};
+        const tier = tierFromOvr(stats?.ovr);
+        const el = buildPlayerCard(m, stats, tier);
+        grid.appendChild(el);
+      });
+      renderClubKits(clubId);
+    });
   }catch(e){
     console.error('Failed to load players', e);
   }
@@ -1126,7 +1125,6 @@ async function loadSquad(clubId){
       const s = stats || {pac:'??',sho:'??',pas:'??',dri:'??',def:'??',phy:'??',ovr:'??'};
       const card = buildPlayerCard({ name, position: pos, playerId: p.playerId||p.playerid }, s, t);
       body.appendChild(card);
-      renderClubKits(clubId);
     });
     renderClubKits(clubId);
   }catch(e){

--- a/server.js
+++ b/server.js
@@ -79,13 +79,6 @@ if (process.env.NODE_ENV === 'test') {
   };
 }
 
-// Headers used when proxying requests to EA's API.  EA's servers expect
-// browser-like headers and will reject requests without them.
-const EA_HEADERS = {
-  'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
-  Accept: 'application/json',
-  Referer: 'https://www.ea.com/',
-};
 
 let cron;
 try {
@@ -351,21 +344,31 @@ app.get('/api/ea/clubs/:clubId/info', async (req, res) => {
   }
 });
 
-// Minimal proxy for club info. EA blocks direct browser requests via CORS so
-// the client must call this endpoint which forwards the request with the
-// required headers.
+// Minimal proxy for club info with caching. This prevents hitting the EA API
+// repeatedly when multiple players from the same club are rendered.
 app.get('/api/club-info/:clubId', async (req, res) => {
-  const clubId = req.params.clubId;
-  const url =
-    `https://proclubs.ea.com/api/fc/clubs/info?platform=common-gen5&clubIds=${clubId}`;
+  const { clubId } = req.params;
+  if (!/^\d+$/.test(String(clubId))) {
+    return res.status(400).json({ error: 'Invalid clubId' });
+  }
+
+  const cached = _clubInfoCache.get(clubId);
+  if (cached && Date.now() - cached.at < CLUB_INFO_TTL_MS) {
+    return res.json({ club: cached.data });
+  }
+
   try {
-    const r = await fetch(url, { headers: EA_HEADERS });
-    const json = await r.json();
-    res.json(json);
+    const info = await limit(() => eaApi.fetchClubInfoWithRetry(clubId));
+    _clubInfoCache.set(clubId, { at: Date.now(), data: info });
+    return res.json({ club: info });
   } catch (err) {
-    res
-      .status(500)
-      .json({ error: 'EA API failed', details: err.toString() });
+    const msg = err?.error || err?.message || 'EA API error';
+    const status = /abort|timeout|timed out|ETIMEDOUT/i.test(String(msg))
+      ? 504
+      : 502;
+    return res
+      .status(status)
+      .json({ error: 'EA API request failed', details: msg });
   }
 });
 


### PR DESCRIPTION
## Summary
- load players via single `/api/players` request and cache club info on the client
- render kits after card batches and avoid duplicate club info fetches
- cache `/api/club-info/:clubId` on the server to limit EA API calls

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden fetching cors)*

------
https://chatgpt.com/codex/tasks/task_e_68abbe87a284832e82eab1bc84e289fa