### PR TITLE
Add club_id to playercards and update related queries

### DIFF
--- a/migrations/2025-11-12_add_club_id_to_playercards.sql
+++ b/migrations/2025-11-12_add_club_id_to_playercards.sql
@@ -1,0 +1,12 @@
+-- Allow player cards to be club-specific
+ALTER TABLE public.playercards
+  ADD COLUMN club_id TEXT NOT NULL REFERENCES public.clubs(club_id);
+
+ALTER TABLE public.playercards
+  DROP CONSTRAINT IF EXISTS playercards_pkey,
+  DROP CONSTRAINT IF EXISTS playercards_player_id_fkey;
+
+ALTER TABLE public.playercards
+  ADD CONSTRAINT playercards_pkey PRIMARY KEY (player_id, club_id),
+  ADD CONSTRAINT playercards_player_fkey FOREIGN KEY (player_id, club_id)
+    REFERENCES public.players(player_id, club_id);


### PR DESCRIPTION
## Summary
- add migration to include club_id on playercards and use composite primary key
- upsert and select playercards by club_id in server logic
- update player card API tests for club_id field

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cors)*

------
https://chatgpt.com/codex/tasks/task_e_68abc7059454832ea93da92085dab6c8