### PR TITLE
Use club player-cards endpoint

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -966,7 +966,7 @@ function updatePlayerCard(card, stats){
 
 async function upgradeClubPlayers(clubId, container){
   try{
-    const d = await fetch(`/api/teams/${encodeURIComponent(clubId)}/players`).then(r=>r.json());
+    const d = await fetch(`/api/clubs/${encodeURIComponent(clubId)}/player-cards`).then(r=>r.json());
     const grid = container || document.querySelector(`.team-card[data-club-id="${clubId}"] .players-grid`);
     if(!grid) return;
     (d.members||[]).forEach(m=>{
@@ -975,7 +975,7 @@ async function upgradeClubPlayers(clubId, container){
       if(!card){
         card = Array.from(grid.querySelectorAll('.player-card')).find(el=>el.dataset.playerName === m.name);
       }
-      const stats = m.stats || (m.vproattr ? parseVpro(m.vproattr) : null);
+      const stats = m.stats;
       if(card && stats) updatePlayerCard(card, stats);
     });
   }catch(e){


### PR DESCRIPTION
## Summary
- Update `upgradeClubPlayers` to fetch club player cards and refresh stats using returned `stats`

## Testing
- `npm test` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68abd74791f0832e8f18b5eb2a39f1ac