### PR TITLE
Fix player cards join with EA members

### DIFF
--- a/migrations/2025-12-01_playercards_composite_key.sql
+++ b/migrations/2025-12-01_playercards_composite_key.sql
@@ -1,0 +1,14 @@
+ALTER TABLE public.playercards
+ADD COLUMN IF NOT EXISTS club_id TEXT;
+
+-- Fill missing club_id from players table if needed
+UPDATE public.playercards pc
+SET club_id = p.club_id
+FROM public.players p
+WHERE pc.player_id = p.player_id AND pc.club_id IS NULL;
+
+-- Add unique constraint for upsert
+ALTER TABLE public.playercards
+DROP CONSTRAINT IF EXISTS playercards_unique;
+ALTER TABLE public.playercards
+ADD CONSTRAINT playercards_unique UNIQUE (player_id, club_id);


### PR DESCRIPTION
## Summary
- join `playercards` with EA club members using `(player_id, club_id)` and name fallback
- add migration ensuring `playercards` has `(player_id, club_id)` unique constraint
- update tests for player card stats and name fallback

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68abdc258b58832e90e45318db8bf103