### PR TITLE
Hide player cards on team grid

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -224,112 +224,90 @@ h2{margin:0 0 10px}
       <div class="team-card" data-club-id="2491998" role="listitem">
         <img class="team-logo" src="/assets/logos/royal-republic-logo.png" alt="Royal Republic logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Royal%20Republic';" />
         <div class="team-meta"><div class="name">Royal Republic</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="1527486" role="listitem">
         <img class="team-logo" src="/assets/logos/gungan-fc.png" alt="Gungan FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Gungan%20FC';" />
         <div class="team-meta"><div class="name">Gungan FC</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="1969494" role="listitem">
         <img class="team-logo" src="/assets/logos/club-frijol.png" alt="Club Frijol logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Club%20Frijol';" />
         <div class="team-meta"><div class="name">Club Frijol</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="2086022" role="listitem">
         <img class="team-logo" src="/assets/logos/brehemen.png" alt="Brehemen logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Brehemen';" />
         <div class="team-meta"><div class="name">Brehemen</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="2462194" role="listitem">
         <img class="team-logo" src="/assets/logos/costa-chica-fc.png" alt="Costa Chica FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Costa%20Chica%20FC';" />
         <div class="team-meta"><div class="name">Costa Chica FC</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="5098824" role="listitem">
         <img class="team-logo" src="/assets/logos/sporting-de-la-ma.png" alt="Sporting de la ma logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Sporting%20de%20la%20ma';" />
         <div class="team-meta"><div class="name">Sporting de la ma</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="4869810" role="listitem">
         <img class="team-logo" src="/assets/logos/afc-tekki.png" alt="Afc Tekki logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Afc%20Tekki';" />
         <div class="team-meta"><div class="name">Afc Tekki</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="576007" role="listitem">
         <img class="team-logo" src="/assets/logos/ethabella-fc.png" alt="Ethabella FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Ethabella%20FC';" />
         <div class="team-meta"><div class="name">Ethabella FC</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="4933507" role="listitem">
         <img class="team-logo" src="/assets/logos/loss-toyz.png" alt="Loss Toyz logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Loss%20Toyz';" />
         <div class="team-meta"><div class="name">Loss Toyz</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="4824736" role="listitem">
         <img class="team-logo" src="/assets/logos/goldengoals-fc.png" alt="GoldenGoals FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=GoldenGoals%20FC';" />
         <div class="team-meta"><div class="name">GoldenGoals FC</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="481847" role="listitem">
         <img class="team-logo" src="/assets/logos/rooney-tunes.png" alt="Rooney tunes logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Rooney%20tunes';" />
         <div class="team-meta"><div class="name">Rooney tunes</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="3050467" role="listitem">
         <img class="team-logo" src="/assets/logos/invincible-afc.png" alt="invincible afc logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=invincible%20afc';" />
         <div class="team-meta"><div class="name">invincible afc</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="4154835" role="listitem">
         <img class="team-logo" src="/assets/logos/khalch-fc.png" alt="khalch Fc logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=khalch%20Fc';" />
         <div class="team-meta"><div class="name">khalch Fc</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="3638105" role="listitem">
         <img class="team-logo" src="/assets/logos/real-mvc.png" alt="Real mvc logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Real%20mvc';" />
         <div class="team-meta"><div class="name">Real mvc</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="55408" role="listitem">
         <img class="team-logo" src="/assets/logos/elite-vt.png" alt="Elite VT logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Elite%20VT';" />
         <div class="team-meta"><div class="name">Elite VT</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="4819681" role="listitem">
         <img class="team-logo" src="/assets/logos/everything-dead.png" alt="EVERYTHING DEAD logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=EVERYTHING%20DEAD';" />
         <div class="team-meta"><div class="name">EVERYTHING DEAD</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="35642" role="listitem">
         <img class="team-logo" src="/assets/logos/ebk-fc.png" alt="EBK FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=EBK%20FC';" />
         <div class="team-meta"><div class="name">EBK FC</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="afc-warriors" role="listitem">
         <img class="team-logo" src="/assets/logos/afc-warriors.png" alt="AFC Warriors logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=AFC%20Warriors';" />
         <div class="team-meta"><div class="name">AFC Warriors</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="jids-trivela" role="listitem">
         <img class="team-logo" src="/assets/logos/jids-trivela.png" alt="Jids Trivela logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Jids%20Trivela';" />
         <div class="team-meta"><div class="name">Jids Trivela</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="razorblack-fc" role="listitem">
         <img class="team-logo" src="/assets/logos/razorblack-fc.png" alt="Razorblack FC logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Razorblack%20FC';" />
         <div class="team-meta"><div class="name">Razorblack FC</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="fc-dhizz" role="listitem">
         <img class="team-logo" src="/assets/logos/fc-dhizz.png" alt="FC Dhizz logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=FC%20Dhizz';" />
         <div class="team-meta"><div class="name">FC Dhizz</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
       <div class="team-card" data-club-id="elite-xi" role="listitem">
         <img class="team-logo" src="/assets/logos/elite-xi.png" alt="Elite xi logo" onerror="this.onerror=null;this.src='https://via.placeholder.com/800x480.png?text=Elite%20xi';" />
         <div class="team-meta"><div class="name">Elite xi</div><div class="record"></div></div>
-        <div class="players-grid"></div>
       </div>
     </div>
   </section>
@@ -991,7 +969,6 @@ async function openTeamView(clubId){
   teamView.innerHTML = `<button id="teamBackBtn">← Back</button>
     <h2>${escapeHtml(name)}</h2>
     <div class="team-wallet">Wallet: TBD</div>
-    <div class="players-grid"></div>`;
   document.getElementById('teamBackBtn').addEventListener('click', closeTeamView);
   const grid = teamView.querySelector('.players-grid');
   let members = [];
@@ -1025,21 +1002,6 @@ async function loadPlayers(){
     (d.players||[]).forEach(p=>{
       const cid = String(p.club_id);
       (playersByClub[cid] ||= []).push(p);
-    });
-    document.querySelectorAll('.team-card').forEach(card=>{
-      const clubId = card.getAttribute('data-club-id');
-      const members = (d.players||[]).filter(p=>String(p.club_id)===clubId);
-      const grid = card.querySelector('.players-grid');
-      if(!grid) return;
-      grid.innerHTML='';
-      members.forEach(p=>{
-        const stats = parseVpro(p.vproattr);
-        const tier = tierFromOvr(stats?stats.ovr:null);
-        const el = buildPlayerCard(p, stats, tier);
-        grid.appendChild(el);
-      });
-      renderClubKits(clubId);
-      upgradeClubPlayers(clubId, grid);
     });
   }catch(e){
     console.error('Failed to load players', e);


### PR DESCRIPTION
## Summary
- Remove player card grids from team list entries so player cards only appear in team view
- Simplify player loading to store data without rendering cards on team list

## Testing
- `npm test` *(fails: 11 failing tests)*


------
https://chatgpt.com/codex/tasks/task_e_68abdec34cb8832eb18af2b9abc7f2a8