### PR TITLE
fix: correct vpro parsing

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -860,14 +860,14 @@ const backBtn = document.getElementById('backBtn');
 
 function parseVpro(vproattr){
   const parts=String(vproattr||'').split('|').map(n=>parseInt(n,10));
-  if(parts.length<26||parts.some(n=>isNaN(n))) return null;
   const avg=a=>Math.round(a.reduce((x,y)=>x+y,0)/a.length);
+  if(parts.length<27||parts.some(n=>isNaN(n))) return {pac:0,sho:0,pas:0,dri:0,def:0,phy:0,ovr:0};
   const pac=avg([parts[0],parts[1]]);
-  const sho=avg([parts[4],parts[5],parts[6]]);
-  const pas=avg([parts[9],parts[10],parts[12]]);
-  const dri=avg([parts[2],parts[7],parts[8]]);
-  const def=avg([parts[19],parts[20]]);
-  const phy=avg([parts[23],parts[24],parts[25]]);
+  const sho=avg([parts[4],parts[5],parts[8],parts[16],parts[17]]);
+  const pas=avg([parts[9],parts[19],parts[12],parts[15],parts[13]]);
+  const dri=avg([parts[2],parts[3],parts[7],parts[11]]);
+  const def=avg([parts[18],parts[10],parts[20],parts[21]]);
+  const phy=avg([parts[22],parts[23],parts[24],parts[25],parts[26]]);
   const ovr=Math.round(pac*0.2+sho*0.2+pas*0.2+dri*0.2+def*0.1+phy*0.1);
   return {pac,sho,pas,dri,def,phy,ovr};
 }

--- a/server.js
+++ b/server.js
@@ -498,7 +498,7 @@ app.get('/api/clubs/:clubId/player-cards', async (req, res) => {
       let rec = id ? cardMap.get(id) : null;
       if (!rec) rec = nameMap.get(m.name) || {};
 
-      const vproattr = rec.vproattr || null;
+      const vproattr = rec.vproattr || m.vproattr || null;
       const stats = vproattr ? parseVpro(vproattr) : null;
 
       return {

--- a/services/playerCards.js
+++ b/services/playerCards.js
@@ -1,15 +1,15 @@
 function parseVpro(vproattr = '') {
   const parts = String(vproattr).split('|').map(n => parseInt(n, 10));
   const avg = arr => Math.round(arr.reduce((a, b) => a + b, 0) / arr.length);
-  if (parts.length < 26) {
+  if (parts.length < 27 || parts.some(n => isNaN(n))) {
     return { pac: 0, sho: 0, pas: 0, dri: 0, def: 0, phy: 0, ovr: 0 };
   }
   const pac = avg([parts[0], parts[1]]);
-  const sho = avg([parts[4], parts[5], parts[6]]);
-  const pas = avg([parts[9], parts[10], parts[12]]);
-  const dri = avg([parts[2], parts[7], parts[8]]);
-  const def = avg([parts[19], parts[20]]);
-  const phy = avg([parts[23], parts[24], parts[25]]);
+  const sho = avg([parts[4], parts[5], parts[8], parts[16], parts[17]]);
+  const pas = avg([parts[9], parts[19], parts[12], parts[15], parts[13]]);
+  const dri = avg([parts[2], parts[3], parts[7], parts[11]]);
+  const def = avg([parts[18], parts[10], parts[20], parts[21]]);
+  const phy = avg([parts[22], parts[23], parts[24], parts[25], parts[26]]);
   const ovr = Math.round(
     pac * 0.2 +
     sho * 0.2 +

--- a/test/playerCards.test.js
+++ b/test/playerCards.test.js
@@ -7,12 +7,12 @@ test('parseVpro computes stats and overall', () => {
   const stats = parseVpro(attrs);
   assert.deepStrictEqual(stats, {
     pac: 93,
-    sho: 73,
-    pas: 83,
-    dri: 85,
-    def: 90,
-    phy: 71,
-    ovr: 83
+    sho: 77,
+    pas: 92,
+    dri: 92,
+    def: 73,
+    phy: 76,
+    ovr: 86
   });
 });
 


### PR DESCRIPTION
## Summary
- fix attribute mapping in parseVpro for PAC/SHO/PAS/DRI/DEF/PHY and compute overall correctly
- return parsed stats in player-cards endpoint and show them on team cards
- update tests for new vpro calculation

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `node --test test/playerCards.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68abe8c31e4c832e96019a6c46f329ea