### PR TITLE
feat: correct vPro attribute card stat mapping

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -860,14 +860,14 @@ const backBtn = document.getElementById('backBtn');
 
 function parseVpro(vproattr){
   const parts=String(vproattr||'').split('|').map(n=>parseInt(n,10));
-  if(parts.length<26||parts.some(n=>isNaN(n))) return null;
+  if(parts.length<27||parts.some(n=>isNaN(n))) return null;
   const avg=a=>Math.round(a.reduce((x,y)=>x+y,0)/a.length);
   const pac=avg([parts[0],parts[1]]);
-  const sho=avg([parts[4],parts[5],parts[6]]);
-  const pas=avg([parts[9],parts[10],parts[12]]);
-  const dri=avg([parts[2],parts[7],parts[8]]);
-  const def=avg([parts[19],parts[20]]);
-  const phy=avg([parts[23],parts[24],parts[25]]);
+  const sho=avg([parts[4],parts[5],parts[8],parts[16],parts[17]]);
+  const pas=avg([parts[9],parts[19],parts[12],parts[15],parts[13]]);
+  const dri=avg([parts[2],parts[3],parts[7],parts[11]]);
+  const def=avg([parts[18],parts[10],parts[20],parts[21]]);
+  const phy=avg([parts[22],parts[23],parts[24],parts[25],parts[26]]);
   const ovr=Math.round(pac*0.2+sho*0.2+pas*0.2+dri*0.2+def*0.1+phy*0.1);
   return {pac,sho,pas,dri,def,phy,ovr};
 }

--- a/services/playerCards.js
+++ b/services/playerCards.js
@@ -1,15 +1,15 @@
 function parseVpro(vproattr = '') {
   const parts = String(vproattr).split('|').map(n => parseInt(n, 10));
   const avg = arr => Math.round(arr.reduce((a, b) => a + b, 0) / arr.length);
-  if (parts.length < 26) {
+  if (parts.length < 27) {
     return { pac: 0, sho: 0, pas: 0, dri: 0, def: 0, phy: 0, ovr: 0 };
   }
   const pac = avg([parts[0], parts[1]]);
-  const sho = avg([parts[4], parts[5], parts[6]]);
-  const pas = avg([parts[9], parts[10], parts[12]]);
-  const dri = avg([parts[2], parts[7], parts[8]]);
-  const def = avg([parts[19], parts[20]]);
-  const phy = avg([parts[23], parts[24], parts[25]]);
+  const sho = avg([parts[4], parts[5], parts[8], parts[16], parts[17]]);
+  const pas = avg([parts[9], parts[19], parts[12], parts[15], parts[13]]);
+  const dri = avg([parts[2], parts[3], parts[7], parts[11]]);
+  const def = avg([parts[18], parts[10], parts[20], parts[21]]);
+  const phy = avg([parts[22], parts[23], parts[24], parts[25], parts[26]]);
   const ovr = Math.round(
     pac * 0.2 +
     sho * 0.2 +

--- a/test/playerAttributes.test.js
+++ b/test/playerAttributes.test.js
@@ -6,18 +6,18 @@ process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
 const { pool } = require('../db');
 const { getPlayerAttributes } = require('../services/playerAttributes');
 
-const sample = '1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26';
+const sample = '1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27';
 
 function expectedOvr() {
-  const stats = { pac:2, sho:6, pas:11, dri:7, def:21, phy:25 }; // computed from sample
+  const stats = { pac:2, sho:11, pas:15, dri:7, def:18, phy:25 }; // computed from sample
   const ovr = Math.round(
     stats.pac*0.2 + stats.sho*0.2 + stats.pas*0.2 +
     stats.dri*0.2 + stats.def*0.1 + stats.phy*0.1
   );
-  return ovr; // should be 10
+  return ovr; // should be 11
 }
 
-const ovr10 = expectedOvr();
+const ovr11 = expectedOvr();
 
 test('getPlayerAttributes uses match data first', async () => {
   const stub = mock.method(pool, 'query', async sql => {
@@ -27,7 +27,7 @@ test('getPlayerAttributes uses match data first', async () => {
     throw new Error('should not query players table');
   });
   const stats = await getPlayerAttributes('p1', 'c1');
-  assert.strictEqual(stats.ovr, ovr10);
+  assert.strictEqual(stats.ovr, ovr11);
   stub.mock.restore();
 });
 
@@ -42,7 +42,7 @@ test('getPlayerAttributes falls back to players table', async () => {
     return { rows: [] };
   });
   const stats = await getPlayerAttributes('p1', 'c1');
-  assert.strictEqual(stats.ovr, ovr10);
+  assert.strictEqual(stats.ovr, ovr11);
   stub.mock.restore();
 });
 

--- a/test/playerCards.test.js
+++ b/test/playerCards.test.js
@@ -7,12 +7,12 @@ test('parseVpro computes stats and overall', () => {
   const stats = parseVpro(attrs);
   assert.deepStrictEqual(stats, {
     pac: 93,
-    sho: 73,
-    pas: 83,
-    dri: 85,
-    def: 90,
-    phy: 71,
-    ovr: 83
+    sho: 77,
+    pas: 92,
+    dri: 92,
+    def: 73,
+    phy: 76,
+    ovr: 86
   });
 });
 

--- a/test/playerCardsApi.test.js
+++ b/test/playerCardsApi.test.js
@@ -7,7 +7,7 @@ const eaApi = require('../services/eaApi');
 const { pool } = require('../db');
 const app = require('../server');
 
-const sampleVpro = '091|094|094|089|072|084|064|095|066|093|064|089|091|094|082|095|083|079|068|089|091|069|091|082|067|065';
+const sampleVpro = '091|094|094|089|072|084|064|095|066|093|064|089|091|094|082|095|083|079|068|089|091|069|091|082|067|065|070';
 
 async function withServer(fn) {
   const server = app.listen(0);


### PR DESCRIPTION
## Summary
- adjust attribute index mapping for card stats and overall rating
- sync front-end parsing logic with new mapping
- update tests and sample data for revised attributes

## Testing
- `npm test` *(fails: Cannot find module 'express' etc. after `npm install` returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68abeb8215b4832e82d56c6adab78647