### PR TITLE
Persist match participant home/away flag

### DIFF
--- a/migrations/2025-12-02_match_participants_is_home_not_null.sql
+++ b/migrations/2025-12-02_match_participants_is_home_not_null.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.match_participants
+  ALTER COLUMN is_home SET NOT NULL;

--- a/server.js
+++ b/server.js
@@ -196,8 +196,9 @@ async function saveEaMatch(match) {
     const c = clubs[cid];
     const name = c?.details?.name || `Club ${cid}`;
     const goals = Number(c?.goals || 0);
+    const isHome = Number(c?.details?.isHome) === 1;
     await q(SQL_UPSERT_CLUB, [cid, name]);
-    await q(SQL_UPSERT_PARTICIPANT, [matchId, cid, null, goals]);
+    await q(SQL_UPSERT_PARTICIPANT, [matchId, cid, isHome, goals]);
   }
 
   if (match.players) {
@@ -649,3 +650,4 @@ if (require.main === module) {
 }
 
 module.exports = app;
+module.exports.saveEaMatch = saveEaMatch;

--- a/test/saveEaMatch.test.js
+++ b/test/saveEaMatch.test.js
@@ -1,0 +1,34 @@
+const { test, mock } = require('node:test');
+const assert = require('assert');
+
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+
+const { pool } = require('../db');
+const { saveEaMatch } = require('../server');
+
+test('saveEaMatch stores home/away flags for clubs', async () => {
+  const calls = [];
+  const queryStub = mock.method(pool, 'query', async (sql, params) => {
+    if (/INSERT INTO public\.match_participants/i.test(sql)) {
+      calls.push(params);
+    }
+    return { rows: [] };
+  });
+
+  const match = {
+    matchId: 'm1',
+    timestamp: 1000,
+    clubs: {
+      '10': { details: { name: 'Alpha', isHome: 1 }, goals: 3 },
+      '20': { details: { name: 'Beta', isHome: 0 }, goals: 1 },
+    },
+  };
+
+  await saveEaMatch(match);
+
+  queryStub.mock.restore();
+  assert.deepStrictEqual(calls, [
+    ['m1', '10', true, 3],
+    ['m1', '20', false, 1],
+  ]);
+});


### PR DESCRIPTION
## Summary
- Parse and store each club's home status when saving EA matches
- Enforce non-null `is_home` in match participants
- Test `saveEaMatch` to ensure home/away flags are persisted

## Testing
- `node --test test/saveEaMatch.test.js`
- `for f in test/*.test.js; do echo "Running $f"; node --test "$f" >/tmp/out.log && tail -n 3 /tmp/out.log; done`


------
https://chatgpt.com/codex/tasks/task_e_68ac1c27fe1c832e8bab84e4e670904b