### PR TITLE
Await initial data sync before starting server

### DIFF
--- a/server.js
+++ b/server.js
@@ -626,19 +626,18 @@ async function bootstrap() {
     console.error('[db] failed to query active database', err);
   }
 
+  if (process.env.NODE_ENV !== 'test') {
+    try {
+      await refreshAllMatches();
+      console.log(`[${new Date().toISOString()}] ✅ Initial sync complete.`);
+    } catch (err) {
+      logger.error({ err }, `[${new Date().toISOString()}] ❌ Initial sync error`);
+    }
+  }
+
   const PORT = process.env.PORT || 3000;
   app.listen(PORT, () => {
     console.log(`Server on :${PORT}`);
-    if (process.env.NODE_ENV !== 'test') {
-      (async () => {
-        try {
-          await refreshAllMatches();
-          console.log(`[${new Date().toISOString()}] ✅ Initial sync complete.`);
-        } catch (err) {
-          logger.error({ err }, `[${new Date().toISOString()}] ❌ Initial sync error`);
-        }
-      })();
-    }
   });
 }
 


### PR DESCRIPTION
## Summary
- Move initial refreshAllMatches call to bootstrap before app.listen
- Await initial sync to ensure match and participant data populate before serving requests

## Testing
- `npm test` *(fails: hangs after printing "TAP version 13"; requires investigation)*

------
https://chatgpt.com/codex/tasks/task_e_68ac203d0850832eb3d3798138758a4c