### PR TITLE
Return team objects in league API

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -1858,6 +1858,9 @@ async function loadLeague(){
 
   let leagueData = { teams:[], standings:[] };
   try { leagueData = await apiGet(`/api/leagues/${encodeURIComponent(LEAGUE_ID)}`); } catch {}
+  if (Array.isArray(leagueData.teams) && leagueData.teams.length) {
+    teams = leagueData.teams;
+  }
   renderLeagueTable(leagueData.standings);
 
   try { const leaders = await apiGet(`/api/leagues/${encodeURIComponent(LEAGUE_ID)}/leaders`); renderLeagueLeaders(leaders); } catch {}
@@ -1893,14 +1896,14 @@ function renderLeagueFixtures(list){
 }
 
 
-function setupLeagueFixtureForm(teamIds){
+function setupLeagueFixtureForm(teamList){
   const homeSel=document.getElementById('leagueHomeSel');
   const awaySel=document.getElementById('leagueAwaySel');
   const roundInput=document.getElementById('leagueRoundInput');
   const whenInput=document.getElementById('leagueWhenInput');
   const createBtn=document.getElementById('leagueFormCreate');
   if(!homeSel||!awaySel||!createBtn) return;
-  const opts=teamIds.map(id=>{ const T=byId(id); return `<option value="${id}">${escapeHtml(T?.name||id)}</option>`; }).join('');
+  const opts=teamList.map(t=>`<option value="${t.id}">${escapeHtml(t.name||t.id)}</option>`).join('');
   homeSel.innerHTML=`<option value="">— choose —</option>${opts}`;
   awaySel.innerHTML=`<option value="">— choose —</option>${opts}`;
   function ensureDifferent(){ if(homeSel.value && awaySel.value && homeSel.value===awaySel.value){ alert('Home and away cannot be the same club.'); awaySel.value=''; } }

--- a/server.js
+++ b/server.js
@@ -574,10 +574,18 @@ const SQL_TOP_ASSISTERS = `
    ORDER BY count DESC, name
    LIMIT 10`;
 
+const SQL_LEAGUE_TEAMS = `
+  SELECT club_id AS "id", club_name AS "name", logo
+    FROM public.clubs
+   WHERE club_id = ANY($1)`;
+
 app.get('/api/leagues/:leagueId', async (_req, res) => {
   try {
-    const { rows } = await q(SQL_LEAGUE_STANDINGS, [CLUB_IDS]);
-    res.json({ teams: CLUB_IDS, standings: rows });
+    const [standings, teams] = await Promise.all([
+      q(SQL_LEAGUE_STANDINGS, [CLUB_IDS]),
+      q(SQL_LEAGUE_TEAMS, [CLUB_IDS])
+    ]);
+    res.json({ teams: teams.rows, standings: standings.rows });
   } catch (err) {
     logger.error({ err }, 'Failed to fetch league standings');
     res.status(500).json({ error: 'Failed to fetch league standings' });


### PR DESCRIPTION
## Summary
- Extend league standings endpoint to fetch team details from database and return full team objects.
- Store fetched teams in client and adapt fixture form to handle team objects.

## Testing
- `npm test` *(fails: process hung without output)*
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_68acc4e34238832e96e81d070d9afbff