### PR TITLE
Remove obsolete logo field from league teams endpoint

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -676,9 +676,10 @@ const FRIENDLIES_ID = 'UPCL_FRIENDLIES_2025'; // current Friendlies id
 
 // Teams
 let teams = [];
+let staticTeams = [];
 
 function buildStaticTeams(){
-  teams = Array.from(document.querySelectorAll('.team-card')).map(card => {
+  staticTeams = Array.from(document.querySelectorAll('.team-card')).map(card => {
     const id = card.getAttribute('data-club-id');
     const name = card.querySelector('.name').textContent.trim();
     const logo = card.querySelector('.team-logo').getAttribute('src');
@@ -686,6 +687,7 @@ function buildStaticTeams(){
     card.addEventListener('click', () => openTeamView(id));
     return team;
   });
+  teams = [...staticTeams];
   document.getElementById('teams-count').textContent = teams.length;
 }
 
@@ -1868,7 +1870,10 @@ async function loadLeague(){
   let leagueData = { teams:[], standings:[] };
   try { leagueData = await apiGet(`/api/leagues/${encodeURIComponent(LEAGUE_ID)}`); } catch {}
   if (Array.isArray(leagueData.teams) && leagueData.teams.length) {
-    teams = leagueData.teams;
+    teams = leagueData.teams.map(t => {
+      const existing = staticTeams.find(s => normalizeId(s.id) === normalizeId(t.id));
+      return existing ? { ...t, logo: existing.logo } : t;
+    });
   }
   renderLeagueTable(leagueData.standings);
 
@@ -1883,7 +1888,7 @@ async function loadLeague(){
 
   const adminEl = document.getElementById('leagueAdmin');
   if (adminEl) adminEl.style.display = isAdmin ? 'block' : 'none';
-  if (isAdmin) setupLeagueFixtureForm(leagueData.teams);
+  if (isAdmin) setupLeagueFixtureForm(teams);
 }
 
 function renderLeagueTable(rows){

--- a/server.js
+++ b/server.js
@@ -607,7 +607,7 @@ const SQL_TOP_ASSISTERS = `
    LIMIT 10`;
 
 const SQL_LEAGUE_TEAMS = `
-  SELECT club_id AS "id", club_name AS "name", logo
+  SELECT club_id AS "id", club_name AS "name"
     FROM public.clubs
    WHERE club_id = ANY($1)`;
 

--- a/test/leagues.test.js
+++ b/test/leagues.test.js
@@ -21,13 +21,16 @@ test('serves league standings', async () => {
     if (/match_participants/i.test(sql)) {
       return { rows: [ { clubId: '1', P: 1, W: 1, D: 0, L: 0, GF: 2, GA: 1, GD: 1, Pts: 3 } ] };
     }
+    if (/from\s+public\.clubs/i.test(sql)) {
+      return { rows: [ { id: '1', name: 'Team 1' } ] };
+    }
     return { rows: [] };
   });
 
   await withServer(async port => {
     const res = await fetch(`http://localhost:${port}/api/leagues/test`);
     const body = await res.json();
-    assert.ok(Array.isArray(body.teams));
+    assert.deepStrictEqual(body.teams, [ { id: '1', name: 'Team 1' } ]);
     assert.deepStrictEqual(body.standings, [ { clubId: '1', P: 1, W: 1, D: 0, L: 0, GF: 2, GA: 1, GD: 1, Pts: 3 } ]);
   });
 


### PR DESCRIPTION
## Summary
- drop nonexistent `logo` column from league teams SQL query
- merge league team data with static logos in client and adjust admin form
- update league tests for new payload shape

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68accd7396a8832e9e1291e7dec029c1