### PR TITLE
Use away_score alias in league matches query

### DIFF
--- a/server.js
+++ b/server.js
@@ -618,7 +618,7 @@ const SQL_LEAGUE_MATCHES = `
          home.club_id AS home,
          away.club_id AS away,
          home.goals AS hs,
-         away.goals AS as
+         away.goals AS away_score
     FROM public.matches m
     JOIN public.match_participants home
       ON home.match_id = m.match_id AND home.is_home = true
@@ -664,7 +664,7 @@ app.get('/api/leagues/:leagueId/matches', async (_req, res) => {
       round: null,
       when: Number(r.when) || null,
       status: 'final',
-      score: { hs: Number(r.hs || 0), as: Number(r.as || 0) },
+      score: { hs: Number(r.hs || 0), as: Number(r.away_score || 0) },
     }));
     res.json({ matches });
   } catch (err) {

--- a/test/leagues.test.js
+++ b/test/leagues.test.js
@@ -96,7 +96,7 @@ test('serves league matches including non-league opponents', async () => {
             home: '2491998',
             away: '999',
             hs: 1,
-            as: 0
+            away_score: 2
           }
         ]
       };
@@ -116,7 +116,7 @@ test('serves league matches including non-league opponents', async () => {
           round: null,
           when: 1,
           status: 'final',
-          score: { hs: 1, as: 0 }
+          score: { hs: 1, as: 2 }
         }
       ]
     });


### PR DESCRIPTION
## Summary
- rename SQL alias `away.goals AS away_score`
- read `away_score` in league matches response
- update league matches test to expect `away_score`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acebae11a4832eb2e7fb9c2f4bc50d