### PR TITLE
Add upcl standings rebuild

### DIFF
--- a/migrations/2025-12-20_upcl_standings_table.sql
+++ b/migrations/2025-12-20_upcl_standings_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS public.upcl_standings (
+  club_id   TEXT PRIMARY KEY,
+  p   INT NOT NULL,
+  w   INT NOT NULL,
+  d   INT NOT NULL,
+  l   INT NOT NULL,
+  gf  INT NOT NULL,
+  ga  INT NOT NULL,
+  gd  INT NOT NULL,
+  pts INT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/scripts/rebuildUpclStandings.js
+++ b/scripts/rebuildUpclStandings.js
@@ -1,0 +1,66 @@
+const { q } = require('../services/pgwrap');
+
+const SQL_LEAGUE_STANDINGS = `
+  WITH matches AS (
+    SELECT home.club_id AS home,
+           away.club_id AS away,
+           home.goals AS home_goals,
+           away.goals AS away_goals
+      FROM public.matches m
+      JOIN public.match_participants home
+        ON home.match_id = m.match_id AND home.is_home = true
+      JOIN public.match_participants away
+        ON away.match_id = m.match_id AND away.is_home = false
+  ), sides AS (
+    SELECT home AS club_id, away AS opp_id, home_goals AS gf, away_goals AS ga
+      FROM matches
+    UNION ALL
+    SELECT away AS club_id, home AS opp_id, away_goals AS gf, home_goals AS ga
+      FROM matches
+  )
+  SELECT c.club_id AS "clubId",
+         COALESCE(COUNT(s.club_id), 0)::int AS "P",
+         COALESCE(SUM(CASE WHEN s.gf > s.ga THEN 1 ELSE 0 END), 0)::int AS "W",
+         COALESCE(SUM(CASE WHEN s.gf = s.ga THEN 1 ELSE 0 END), 0)::int AS "D",
+         COALESCE(SUM(CASE WHEN s.gf < s.ga THEN 1 ELSE 0 END), 0)::int AS "L",
+         COALESCE(SUM(s.gf), 0)::int AS "GF",
+         COALESCE(SUM(s.ga), 0)::int AS "GA",
+         COALESCE(SUM(s.gf - s.ga), 0)::int AS "GD",
+         COALESCE(SUM(CASE WHEN s.gf > s.ga THEN 3 WHEN s.gf = s.ga THEN 1 ELSE 0 END), 0)::int AS "Pts"
+    FROM public.clubs c
+    LEFT JOIN sides s ON c.club_id = s.club_id
+   GROUP BY c.club_id
+   ORDER BY "Pts" DESC, "GD" DESC, "GF" DESC`;
+
+const SQL_UPSERT_STANDING = `
+  INSERT INTO public.upcl_standings (club_id, p, w, d, l, gf, ga, gd, pts, updated_at)
+  VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,NOW())
+  ON CONFLICT (club_id) DO UPDATE SET
+    p = EXCLUDED.p,
+    w = EXCLUDED.w,
+    d = EXCLUDED.d,
+    l = EXCLUDED.l,
+    gf = EXCLUDED.gf,
+    ga = EXCLUDED.ga,
+    gd = EXCLUDED.gd,
+    pts = EXCLUDED.pts,
+    updated_at = NOW()
+`;
+
+async function rebuildUpclStandings() {
+  const { rows } = await q(SQL_LEAGUE_STANDINGS);
+  for (const r of rows) {
+    await q(SQL_UPSERT_STANDING, [r.clubId, r.P, r.W, r.D, r.L, r.GF, r.GA, r.GD, r.Pts]);
+  }
+}
+
+module.exports = { rebuildUpclStandings };
+
+if (require.main === module) {
+  rebuildUpclStandings()
+    .then(() => process.exit(0))
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/server.js
+++ b/server.js
@@ -24,6 +24,7 @@ const eaApi = require('./services/eaApi');
 const { q } = require('./services/pgwrap');
 const { runMigrations } = require('./services/migrate');
 const { parseVpro, tierFromStats } = require('./services/playerCards');
+const { rebuildUpclStandings } = require('./scripts/rebuildUpclStandings');
 
 // SQL statements for saving EA matches
 const SQL_INSERT_MATCH = `
@@ -259,6 +260,9 @@ async function refreshAllMatches(clubIds) {
   const ids = clubIds && clubIds.length ? clubIds : resolveClubIds();
   for (const clubId of ids) {
     await refreshClubMatches(clubId);
+  }
+  if (process.env.NODE_ENV !== 'test') {
+    await rebuildUpclStandings();
   }
 }
 


### PR DESCRIPTION
## Summary
- create upcl_standings table migration
- add rebuildUpclStandings script to compute standings and store in table
- rebuild standings after refreshAllMatches

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad4679678c832ebc24d92649ec029e