### PR TITLE
Add UPCL leaders materialized view and API

### DIFF
--- a/migrations/upcl_leaders.sql
+++ b/migrations/upcl_leaders.sql
@@ -1,0 +1,31 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.upcl_leaders AS
+WITH league_players AS (
+  SELECT p.club_id, p.name, p.goals, p.assists
+    FROM public.players p
+    JOIN public.upcl_standings s ON s.club_id = p.club_id
+),
+scorers AS (
+  SELECT 'scorer'::text AS type,
+         club_id,
+         name,
+         goals AS count,
+         ROW_NUMBER() OVER (ORDER BY goals DESC, name) AS rn
+    FROM league_players
+   WHERE goals > 0
+),
+assisters AS (
+  SELECT 'assister'::text AS type,
+         club_id,
+         name,
+         assists AS count,
+         ROW_NUMBER() OVER (ORDER BY assists DESC, name) AS rn
+    FROM league_players
+   WHERE assists > 0
+)
+SELECT type, club_id, name, count
+  FROM (
+    SELECT type, club_id, name, count, rn FROM scorers WHERE rn <= 10
+    UNION ALL
+    SELECT type, club_id, name, count, rn FROM assisters WHERE rn <= 10
+  ) AS leaders
+ ORDER BY type, count DESC, name;

--- a/test/leagues.test.js
+++ b/test/leagues.test.js
@@ -92,11 +92,13 @@ test('standings include matches against non-league opponents', async () => {
 
 test('serves league leaders', async () => {
   const stub = mock.method(pool, 'query', async sql => {
-    if (/goals::int/i.test(sql)) {
-      return { rows: [ { clubId: '1', name: 'A', count: 5 } ] };
-    }
-    if (/assists::int/i.test(sql)) {
-      return { rows: [ { clubId: '2', name: 'B', count: 3 } ] };
+    if (/upcl_leaders/i.test(sql)) {
+      return {
+        rows: [
+          { type: 'scorer', clubId: '1', name: 'A', count: 5 },
+          { type: 'assister', clubId: '2', name: 'B', count: 3 }
+        ]
+      };
     }
     return { rows: [] };
   });


### PR DESCRIPTION
## Summary
- add `upcl_leaders` materialized view to track top scorers and assisters
- expose `/api/leagues/:leagueId/leaders` backed by new `getUpclLeaders` helper
- refresh leaderboard view after match imports to keep data current

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad47a8d1cc832ea1a821dce6d1fd31