### PR TITLE
Refresh league data without home/away dependency

### DIFF
--- a/test/leagues.test.js
+++ b/test/leagues.test.js
@@ -62,10 +62,10 @@ test('standings include teams with zero matches', async () => {
 
 test('standings include matches against non-league opponents', async () => {
   const stub = mock.method(pool, 'query', async sql => {
-    if (/home\.club_id\s*=\s*ANY\(\$1\)\s+OR\s+away\.club_id\s*=\s*ANY\(\$1\)/i.test(sql)) {
+    if (/a\.club_id\s*=\s*ANY\(\$1\)\s+OR\s+b\.club_id\s*=\s*ANY\(\$1\)/i.test(sql)) {
       assert.match(
         sql,
-        /home\.club_id\s*=\s*ANY\(\$1\)\s+OR\s+away\.club_id\s*=\s*ANY\(\$1\)/i
+        /a\.club_id\s*=\s*ANY\(\$1\)\s+OR\s+b\.club_id\s*=\s*ANY\(\$1\)/i
       );
       return {
         rows: [
@@ -118,7 +118,7 @@ test('serves league matches including non-league opponents', async () => {
     if (/FROM\s+public\.matches/i.test(sql)) {
       assert.match(
         sql,
-        /home\.club_id\s*=\s*ANY\(\$1\)\s+OR\s+away\.club_id\s*=\s*ANY\(\$1\)/i
+        /a\.club_id\s*=\s*ANY\(\$1\)\s+OR\s+b\.club_id\s*=\s*ANY\(\$1\)/i
       );
       return {
         rows: [


### PR DESCRIPTION
## Summary
- Build league standings by pairing match participants without relying on home/away flags
- Fetch league match list using participant pairings rather than home/away markers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad3d3d18f0832eaabd55065bb334e0