### PR TITLE
add league standings table and api

### DIFF
--- a/migrations/2025-12-31_league_standings_table.sql
+++ b/migrations/2025-12-31_league_standings_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS public.league_standings (
+  club_id TEXT PRIMARY KEY REFERENCES public.clubs(club_id),
+  points INT DEFAULT 0,
+  wins INT DEFAULT 0,
+  losses INT DEFAULT 0,
+  draws INT DEFAULT 0,
+  goals_for INT DEFAULT 0,
+  goals_against INT DEFAULT 0,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/scripts/rebuildLeagueStandings.js
+++ b/scripts/rebuildLeagueStandings.js
@@ -1,0 +1,69 @@
+const { q } = require('../services/pgwrap');
+
+const SQL_COMPUTE = `
+  WITH club_match AS (
+    SELECT
+      c.cid AS club_id,
+      (m.raw->'clubs'->c.cid->>'wins')::int    AS wins,
+      (m.raw->'clubs'->c.cid->>'losses')::int  AS losses,
+      (m.raw->'clubs'->c.cid->>'ties')::int    AS draws,
+      (m.raw->'clubs'->c.cid->>'goals')::int   AS goals_for,
+      (m.raw->'clubs'->o.opp_cid->>'goals')::int AS goals_against
+    FROM public.matches m
+    CROSS JOIN LATERAL jsonb_object_keys(m.raw->'clubs') AS c(cid)
+    CROSS JOIN LATERAL (
+      SELECT key AS opp_cid FROM jsonb_object_keys(m.raw->'clubs') key
+      WHERE key <> c.cid
+      LIMIT 1
+    ) AS o
+  )
+  SELECT club_id,
+         SUM(wins * 3 + draws) AS points,
+         SUM(wins) AS wins,
+         SUM(losses) AS losses,
+         SUM(draws) AS draws,
+         SUM(goals_for) AS goals_for,
+         SUM(goals_against) AS goals_against
+    FROM club_match
+   GROUP BY club_id
+`;
+
+const SQL_UPSERT = `
+  INSERT INTO public.league_standings
+    (club_id, points, wins, losses, draws, goals_for, goals_against, updated_at)
+  VALUES ($1,$2,$3,$4,$5,$6,$7,NOW())
+  ON CONFLICT (club_id) DO UPDATE SET
+    points = EXCLUDED.points,
+    wins = EXCLUDED.wins,
+    losses = EXCLUDED.losses,
+    draws = EXCLUDED.draws,
+    goals_for = EXCLUDED.goals_for,
+    goals_against = EXCLUDED.goals_against,
+    updated_at = NOW()
+`;
+
+async function rebuildLeagueStandings() {
+  const { rows } = await q(SQL_COMPUTE);
+  for (const r of rows) {
+    await q(SQL_UPSERT, [
+      r.club_id,
+      r.points,
+      r.wins,
+      r.losses,
+      r.draws,
+      r.goals_for,
+      r.goals_against,
+    ]);
+  }
+}
+
+module.exports = { rebuildLeagueStandings };
+
+if (require.main === module) {
+  rebuildLeagueStandings()
+    .then(() => process.exit(0))
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/test/leagueStandingsApi.test.js
+++ b/test/leagueStandingsApi.test.js
@@ -1,0 +1,46 @@
+const { test, mock } = require('node:test');
+const assert = require('assert');
+const path = require('path');
+
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+process.env.LEAGUE_CLUBS_PATH = path.join(__dirname, 'fixtures', 'leagueClubs.json');
+
+const { pool } = require('../db');
+
+async function withServer(fn) {
+  const app = require('../server');
+  const server = app.listen(0);
+  try {
+    const port = server.address().port;
+    await fn(port);
+  } finally {
+    server.close();
+  }
+}
+
+test('serves league standings table', async () => {
+  const stub = mock.method(pool, 'query', async sql => {
+    if (/league_standings/i.test(sql)) {
+      return {
+        rows: [
+          { clubId: '1', clubName: 'Alpha', points: 3, wins: 1, losses: 0, draws: 0, goalsFor: 2, goalsAgainst: 1 },
+          { clubId: '2', clubName: 'Beta', points: 1, wins: 0, losses: 0, draws: 1, goalsFor: 1, goalsAgainst: 1 }
+        ]
+      };
+    }
+    return { rows: [] };
+  });
+
+  await withServer(async port => {
+    const res = await fetch(`http://localhost:${port}/api/league`);
+    const body = await res.json();
+    assert.deepStrictEqual(body, {
+      standings: [
+        { clubId: '1', clubName: 'Alpha', points: 3, wins: 1, losses: 0, draws: 0, goalsFor: 2, goalsAgainst: 1 },
+        { clubId: '2', clubName: 'Beta', points: 1, wins: 0, losses: 0, draws: 1, goalsFor: 1, goalsAgainst: 1 }
+      ]
+    });
+  });
+
+  stub.mock.restore();
+});


### PR DESCRIPTION
## Summary
- create `league_standings` table for persistent league table tracking
- add script to aggregate match results into standings and update on refresh
- expose `/api/league` endpoint to serve ordered league table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad543ce6fc832eae1b735776ae7e9a