### PR TITLE
Use BIGINT club IDs for league standings table

### DIFF
--- a/migrations/2025-12-31_league_standings_table.sql
+++ b/migrations/2025-12-31_league_standings_table.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS public.league_standings (
-  club_id TEXT PRIMARY KEY REFERENCES public.clubs(club_id),
+  club_id BIGINT PRIMARY KEY REFERENCES public.clubs(club_id),
   points INT DEFAULT 0,
   wins INT DEFAULT 0,
   losses INT DEFAULT 0,

--- a/scripts/rebuildLeagueStandings.js
+++ b/scripts/rebuildLeagueStandings.js
@@ -3,7 +3,7 @@ const { q } = require('../services/pgwrap');
 const SQL_COMPUTE = `
   WITH club_match AS (
     SELECT
-      c.cid AS club_id,
+      c.cid::bigint AS club_id,
       (m.raw->'clubs'->c.cid->>'wins')::int    AS wins,
       (m.raw->'clubs'->c.cid->>'losses')::int  AS losses,
       (m.raw->'clubs'->c.cid->>'ties')::int    AS draws,


### PR DESCRIPTION
## Summary
- make league_standings.club_id a BIGINT referencing clubs
- cast JSON club ids to BIGINT when rebuilding standings

## Testing
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres node - <<'NODE'
const { q } = require('./services/pgwrap');
const fs = require('fs');
const sql = fs.readFileSync('migrations/2025-12-31_league_standings_table.sql','utf8');
q(sql).then(() => { console.log('migration ok'); process.exit(0); }).catch(e => { console.error('migration fail', e); process.exit(1); });
NODE`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres node scripts/rebuildLeagueStandings.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad57289690832e8a06ba3b4d8dd357