### PR TITLE
feat: build standings from matches

### DIFF
--- a/test/leagueStandingsApi.test.js
+++ b/test/leagueStandingsApi.test.js
@@ -20,7 +20,7 @@ async function withServer(fn) {
 
 test('serves league standings table', async () => {
   const stub = mock.method(pool, 'query', async sql => {
-    if (/league_standings/i.test(sql)) {
+    if (/jsonb_object_keys/i.test(sql)) {
       return {
         rows: [
           { clubId: '1', clubName: 'Alpha', points: 3, wins: 1, losses: 0, draws: 0, goalsFor: 2, goalsAgainst: 1 },


### PR DESCRIPTION
## Summary
- compute league standings from `matches.raw`
- expose `/api/league` with new standings query
- update tests for new standings implementation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad5959e06c832e93875b2a0f6cdb65