### PR TITLE
Filter league API by configured clubs

### DIFF
--- a/test/leagueStandingsApi.test.js
+++ b/test/leagueStandingsApi.test.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
 process.env.LEAGUE_CLUBS_PATH = path.join(__dirname, 'fixtures', 'leagueClubs.json');
+process.env.DEFAULT_LEAGUE_ID = 'test';
 
 const { pool } = require('../db');
 
@@ -19,14 +20,15 @@ async function withServer(fn) {
 }
 
 test('serves league standings table', async () => {
-  const stub = mock.method(pool, 'query', async sql => {
+  const stub = mock.method(pool, 'query', async (sql, params) => {
     if (/jsonb_object_keys/i.test(sql)) {
-      return {
-        rows: [
-          { club_id: '1', wins: 1, losses: 0, draws: 0, goals_for: 2, goals_against: 1, points: 3 },
-          { club_id: '2', wins: 0, losses: 0, draws: 1, goals_for: 1, goals_against: 1, points: 1 }
-        ]
-      };
+      assert.match(sql, /WHERE cid = ANY\(\$1\)/i);
+      assert.deepStrictEqual(params, [['1']]);
+      const rows = [
+        { club_id: '1', wins: 1, losses: 0, draws: 0, goals_for: 2, goals_against: 1, points: 3 },
+        { club_id: '2', wins: 0, losses: 0, draws: 1, goals_for: 1, goals_against: 1, points: 1 }
+      ].filter(r => params[0].includes(r.club_id));
+      return { rows };
     }
     return { rows: [] };
   });
@@ -36,8 +38,7 @@ test('serves league standings table', async () => {
     const body = await res.json();
     assert.deepStrictEqual(body, {
       standings: [
-        { club_id: '1', wins: 1, losses: 0, draws: 0, goals_for: 2, goals_against: 1, points: 3 },
-        { club_id: '2', wins: 0, losses: 0, draws: 1, goals_for: 1, goals_against: 1, points: 1 }
+        { club_id: '1', wins: 1, losses: 0, draws: 0, goals_for: 2, goals_against: 1, points: 3 }
       ]
     });
   });


### PR DESCRIPTION
## Summary
- Restrict `/api/league` standings to clubs resolved for the default league
- Adjust league standings API test to expect filtering and verify SQL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad5efb992c832eab27571858b8e75d