### PR TITLE
Add league leaders endpoint and UI integration

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -508,7 +508,23 @@ h2{margin:0 0 10px}
 
   <!-- LEAGUE STANDINGS -->
   <section id="leagueView" style="display:none">
-    <h2>League Standings</h2>
+    <h2>Top Scorers</h2>
+    <table id="leagueTopScorers" class="league-table">
+      <thead>
+        <tr><th>Player</th><th>Club</th><th>G/A</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+
+    <h2>Top Assisters</h2>
+    <table id="leagueTopAssisters" class="league-table" style="margin-top:12px">
+      <thead>
+        <tr><th>Player</th><th>Club</th><th>G/A</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+
+    <h2 style="margin-top:16px">League Standings</h2>
     <table class="league-table">
       <thead>
         <tr><th>Club</th><th>W</th><th>D</th><th>L</th><th>GF</th><th>GA</th><th>Pts</th></tr>
@@ -765,7 +781,7 @@ navMarket.onclick      = ()=> setNav('market');
 navFxPublic.onclick    = ()=> setNav('fixturesPublic');
 navFxSched.onclick     = ()=> setNav('fixturesSched');
 navChampions.onclick   = async ()=> { setNav('champions'); await loadChampions(); };
-navLeague.onclick      = async ()=> { setNav('league'); await loadLeague(); };
+navLeague.onclick      = ()=> { setNav('league'); loadLeague(); };
 navFriendlies.onclick  = async ()=> { setNav('friendlies'); await loadFriendlies(); };
 
 // auth / admin / manager
@@ -1828,10 +1844,38 @@ function setupCcFixtureForm(){
 }
 
 async function loadLeague(){
-  const d = await apiGet('/api/league');
+  const [leaders, standings] = await Promise.all([
+    apiGet('/api/league/leaders'),
+    apiGet('/api/league')
+  ]);
+
+  const scorersBody = document.querySelector('#leagueTopScorers tbody');
+  scorersBody.innerHTML = '';
+  (leaders.scorers || []).forEach(row => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${escapeHtml(row.name)}</td>
+      <td>${escapeHtml((typeof CLUB_NAMES !== 'undefined' && CLUB_NAMES[row.club_id]) || row.club_id)}</td>
+      <td>${row.count}</td>
+    `;
+    scorersBody.appendChild(tr);
+  });
+
+  const assistersBody = document.querySelector('#leagueTopAssisters tbody');
+  assistersBody.innerHTML = '';
+  (leaders.assisters || []).forEach(row => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${escapeHtml(row.name)}</td>
+      <td>${escapeHtml((typeof CLUB_NAMES !== 'undefined' && CLUB_NAMES[row.club_id]) || row.club_id)}</td>
+      <td>${row.count}</td>
+    `;
+    assistersBody.appendChild(tr);
+  });
+
   const body = document.getElementById('leagueTableBody');
   body.innerHTML = '';
-  (d.standings || []).forEach(row => {
+  (standings.standings || []).forEach(row => {
     const tr = document.createElement('tr');
     tr.innerHTML = `
       <td>${escapeHtml((typeof CLUB_NAMES !== 'undefined' && CLUB_NAMES[row.club_id]) || row.club_id)}</td>

--- a/test/leagueLeadersApi.test.js
+++ b/test/leagueLeadersApi.test.js
@@ -1,0 +1,45 @@
+const { test, mock } = require('node:test');
+const assert = require('assert');
+const path = require('path');
+
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+process.env.LEAGUE_CLUBS_PATH = path.join(__dirname, 'fixtures', 'leagueClubs.json');
+process.env.DEFAULT_LEAGUE_ID = 'test';
+
+const { pool } = require('../db');
+
+async function withServer(fn) {
+  const app = require('../server');
+  const server = app.listen(0);
+  try {
+    const port = server.address().port;
+    await fn(port);
+  } finally {
+    server.close();
+  }
+}
+
+test('serves league leaders', async () => {
+  const scorerRows = [{ club_id: '1', name: 'Alice', count: 3 }];
+  const assisterRows = [{ club_id: '1', name: 'Bob', count: 5 }];
+
+  const stub = mock.method(pool, 'query', async (sql, params) => {
+    if (/SUM\(goals\)/i.test(sql)) {
+      assert.deepStrictEqual(params, [['1']]);
+      return { rows: scorerRows };
+    }
+    if (/SUM\(assists\)/i.test(sql)) {
+      assert.deepStrictEqual(params, [['1']]);
+      return { rows: assisterRows };
+    }
+    return { rows: [] };
+  });
+
+  await withServer(async port => {
+    const res = await fetch(`http://localhost:${port}/api/league/leaders`);
+    const body = await res.json();
+    assert.deepStrictEqual(body, { scorers: scorerRows, assisters: assisterRows });
+  });
+
+  stub.mock.restore();
+});


### PR DESCRIPTION
## Summary
- Add `/api/league/leaders` endpoint returning top scorers and assisters
- Display league leaders tables and fetch data on league view
- Cover league leaders endpoint with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad67de7314832e890dda1454fb50c5