### PR TITLE
Fix player card layout to prevent overflow

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -79,16 +79,16 @@ h2{margin:0 0 10px}
   margin-top: 12px; /* pick 12px instead of 10px for consistency */
   width: 100%;
 }
-.player-card{position:relative;width:200px;height:280px;flex:0 1 auto}
+.player-card{position:relative;width:200px;height:280px;flex:0 1 auto;overflow:hidden}
 .card-frame{width:100%;height:100%;object-fit:cover;border-radius:12px}
-.card-overlay{position:absolute;top:0;left:0;width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:flex-end;padding:12px;color:#fff;text-shadow:0 0 6px black;z-index:3}
+.card-overlay{position:absolute;top:0;left:0;width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:flex-end;padding:12px;color:#fff;text-shadow:0 0 6px black;z-index:3;text-align:center}
 .player-silhouette{position:absolute;top:20%;left:50%;transform:translateX(-50%);width:70%;opacity:.85;z-index:1}
 .player-kit{position:absolute;top:20%;left:50%;transform:translateX(-50%);width:70%;z-index:2}
 .player-kit-box{position:absolute;top:20%;left:50%;transform:translateX(-50%);width:70%;height:70%;z-index:2;border-radius:8px}
-.player-overall{font-size:28px;font-weight:900}
-.player-name{font-size:16px;font-weight:bold}
-.player-position{font-size:14px;font-weight:600;margin-bottom:8px}
-.player-stats{font-size:14px;display:grid;grid-template-columns:repeat(2,1fr);gap:2px;text-align:left}
+.player-overall{font-size:28px;font-weight:900;margin-top:auto}
+.player-name{font-size:16px;font-weight:bold;text-align:center}
+.player-position{font-size:14px;font-weight:600;margin-bottom:8px;text-align:center}
+.player-stats{font-size:12px;display:grid;grid-template-columns:repeat(2,1fr);gap:2px;text-align:left;width:100%}
 
 /* Generic card */
 .m-card{background:#110000;border:1px solid #2a0000;border-radius:12px;box-shadow:0 6px 18px rgba(255,0,0,.15);padding:12px}


### PR DESCRIPTION
## Summary
- hide overflowing content on `.player-card`
- align card overlay elements with flexbox and center name/position
- shrink stat font size so numbers remain inside the card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad73d9e76c832ea2cc3c948886c94c