### PR TITLE
Use club names in league view

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -1858,7 +1858,7 @@ async function loadLeague(){
       rowDiv.appendChild(card);
       const info = document.createElement('div');
       info.className = 'podium-info';
-      const clubName = (typeof CLUB_NAMES !== 'undefined' && CLUB_NAMES[row.club_id]) || row.club_id;
+      const clubName = byId(row.club_id)?.name || row.club_id;
       info.innerHTML = `<div>${escapeHtml(row.name)}</div><div class="muted">${escapeHtml(clubName)} — ${row.count} ${label}</div>`;
       rowDiv.appendChild(info);
       el.appendChild(rowDiv);
@@ -1875,7 +1875,7 @@ async function loadLeague(){
   (standings.standings || []).forEach(row => {
     const tr = document.createElement('tr');
     tr.innerHTML = `
-      <td>${escapeHtml((typeof CLUB_NAMES !== 'undefined' && CLUB_NAMES[row.club_id]) || row.club_id)}</td>
+      <td>${escapeHtml(byId(row.club_id)?.name || row.club_id)}</td>
       <td>${row.wins}</td>
       <td>${row.draws}</td>
       <td>${row.losses}</td>


### PR DESCRIPTION
## Summary
- Look up club names via `byId` when rendering league podium and standings
- Ensure league table and top performer sections display club names instead of numeric IDs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae6d0c0fa8832eb5e3f4c06eb35c86