### PR TITLE
Add stats integrity check comparing player and team goals

### DIFF
--- a/scripts/rebuildLeagueStandings.js
+++ b/scripts/rebuildLeagueStandings.js
@@ -1,4 +1,5 @@
 const { q } = require('../services/pgwrap');
+const { checkStatsIntegrity } = require('../services/statsIntegrity');
 
 const SQL_COMPUTE = `
   WITH club_match AS (
@@ -61,6 +62,14 @@ module.exports = { rebuildLeagueStandings };
 
 if (require.main === module) {
   rebuildLeagueStandings()
+    .then(async () => {
+      const mismatches = await checkStatsIntegrity();
+      for (const m of mismatches) {
+        console.warn(
+          `Stats mismatch match ${m.match_id} club ${m.club_id}: players=${m.player_goals} team=${m.team_goals}`
+        );
+      }
+    })
     .then(() => process.exit(0))
     .catch(err => {
       console.error(err);

--- a/services/statsIntegrity.js
+++ b/services/statsIntegrity.js
@@ -1,0 +1,19 @@
+const pg = require('./pgwrap');
+
+const SQL = `
+  SELECT mp.match_id, mp.club_id,
+         COALESCE(SUM(pms.goals), 0)::int AS player_goals,
+         mp.goals::int AS team_goals
+    FROM public.match_participants mp
+    LEFT JOIN public.player_match_stats pms
+           ON pms.match_id = mp.match_id AND pms.club_id = mp.club_id
+   GROUP BY mp.match_id, mp.club_id, mp.goals
+  HAVING COALESCE(SUM(pms.goals), 0)::int <> mp.goals::int
+`;
+
+async function checkStatsIntegrity() {
+  const { rows } = await pg.q(SQL);
+  return rows;
+}
+
+module.exports = { checkStatsIntegrity };

--- a/test/statsIntegrity.test.js
+++ b/test/statsIntegrity.test.js
@@ -1,0 +1,29 @@
+const { test, mock } = require('node:test');
+const assert = require('assert');
+
+const pg = require('../services/pgwrap');
+const { checkStatsIntegrity } = require('../services/statsIntegrity');
+
+const mismatches = [
+  { match_id: 1, club_id: 10, player_goals: 1, team_goals: 2 }
+];
+
+test('detects mismatched player and team goals', async () => {
+  const stub = mock.method(pg, 'q', async sql => {
+    assert.match(sql, /match_participants/i);
+    assert.match(sql, /player_match_stats/i);
+    return { rows: mismatches };
+  });
+
+  const rows = await checkStatsIntegrity();
+  assert.deepStrictEqual(rows, mismatches);
+
+  stub.mock.restore();
+});
+
+test('returns empty array when totals match', async () => {
+  const stub = mock.method(pg, 'q', async () => ({ rows: [] }));
+  const rows = await checkStatsIntegrity();
+  assert.deepStrictEqual(rows, []);
+  stub.mock.restore();
+});


### PR DESCRIPTION
## Summary
- ensure player goals sum matches team goals via new `checkStatsIntegrity` service
- log mismatched goal totals after rebuilding league standings
- test detection of mismatched and matching goal totals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae74738568832e8b0f06d85a73afc1