### PR TITLE
Expand player stats aggregation

### DIFF
--- a/migrations/2026-02-01_expand_player_stats.sql
+++ b/migrations/2026-02-01_expand_player_stats.sql
@@ -1,0 +1,25 @@
+ALTER TABLE public.player_match_stats
+  ADD COLUMN realtimegame integer DEFAULT 0,
+  ADD COLUMN shots integer DEFAULT 0,
+  ADD COLUMN passesmade integer DEFAULT 0,
+  ADD COLUMN passattempts integer DEFAULT 0,
+  ADD COLUMN tacklesmade integer DEFAULT 0,
+  ADD COLUMN tackleattempts integer DEFAULT 0,
+  ADD COLUMN cleansheetsany integer DEFAULT 0,
+  ADD COLUMN saves integer DEFAULT 0,
+  ADD COLUMN goalsconceded integer DEFAULT 0,
+  ADD COLUMN rating double precision DEFAULT 0,
+  ADD COLUMN mom integer DEFAULT 0;
+
+ALTER TABLE public.players
+  ADD COLUMN realtimegame integer DEFAULT 0,
+  ADD COLUMN shots integer DEFAULT 0,
+  ADD COLUMN passesmade integer DEFAULT 0,
+  ADD COLUMN passattempts integer DEFAULT 0,
+  ADD COLUMN tacklesmade integer DEFAULT 0,
+  ADD COLUMN tackleattempts integer DEFAULT 0,
+  ADD COLUMN cleansheetsany integer DEFAULT 0,
+  ADD COLUMN saves integer DEFAULT 0,
+  ADD COLUMN goalsconceded integer DEFAULT 0,
+  ADD COLUMN rating double precision DEFAULT 0,
+  ADD COLUMN mom integer DEFAULT 0;

--- a/public/teams.html
+++ b/public/teams.html
@@ -532,7 +532,9 @@ h2{margin:0 0 10px}
   <section id="leagueView" style="display:none">
     <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap">
       <h2>League Standings</h2>
-      <button id="statsToggleBtn" class="chip">Stats</button>
+      <div id="statsBtnHolderLeague">
+        <button id="statsToggleBtn" class="chip">Stats</button>
+      </div>
     </div>
     <div class="league-grid">
       <div>
@@ -543,8 +545,15 @@ h2{margin:0 0 10px}
           <tbody id="leagueTableBody"></tbody>
         </table>
       </div>
-      <div id="statsCol" style="display:none"></div>
     </div>
+  </section>
+
+  <section id="statsView" style="display:none">
+    <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap">
+      <h2>League Stats</h2>
+      <div id="statsBtnHolderStats"></div>
+    </div>
+    <div class="leaderboards"></div>
   </section>
 
   <!-- FRIENDLIES -->
@@ -1867,11 +1876,23 @@ async function loadLeague(){
   renderStats(players.players || []);
 
   const toggleBtn = document.getElementById('statsToggleBtn');
-  const statsCol = document.getElementById('statsCol');
+  const leagueView = document.getElementById('leagueView');
+  const statsView = document.getElementById('statsView');
+  const holderLeague = document.getElementById('statsBtnHolderLeague');
+  const holderStats = document.getElementById('statsBtnHolderStats');
+
+  // reset view
+  statsView.style.display = 'none';
+  leagueView.style.display = 'block';
+  holderLeague.appendChild(toggleBtn);
+  toggleBtn.textContent = 'Stats';
+
   toggleBtn.onclick = () => {
-    const show = statsCol.style.display === 'none';
-    statsCol.style.display = show ? 'block' : 'none';
-    toggleBtn.textContent = show ? 'Standings' : 'Stats';
+    const showStats = statsView.style.display === 'none';
+    statsView.style.display = showStats ? 'block' : 'none';
+    leagueView.style.display = showStats ? 'none' : 'block';
+    (showStats ? holderStats : holderLeague).appendChild(toggleBtn);
+    toggleBtn.textContent = showStats ? 'Standings' : 'Stats';
   };
 }
 
@@ -1940,7 +1961,9 @@ function per90(val, mins){ const m = Number(mins)||0; return m ? (Number(val||0)
 function pct(num, den){ const d = Number(den)||0; return d ? (Number(num||0)/d)*100 : 0; }
 
 function renderStats(players){
-  const container = document.getElementById('statsCol');
+  const section = document.getElementById('statsView');
+  const container = section.querySelector('.leaderboards');
+  if (!container) return;
   container.innerHTML = '';
   STAT_CATEGORIES.forEach(cat => {
     const rows = players.map(p => ({ p, v:cat.calc(p) }))

--- a/scripts/rebuildPlayerStats.js
+++ b/scripts/rebuildPlayerStats.js
@@ -1,7 +1,12 @@
 const { q } = require('../services/pgwrap');
 
 const SQL_REBUILD_PLAYER_STATS = `
-  INSERT INTO public.players (player_id, club_id, name, position, vproattr, goals, assists, last_seen)
+  INSERT INTO public.players (
+    player_id, club_id, name, position, vproattr,
+    goals, assists, realtimegame, shots, passesmade, passattempts,
+    tacklesmade, tackleattempts, cleansheetsany, saves, goalsconceded,
+    rating, mom, last_seen
+  )
   SELECT pm.player_id,
          pm.club_id,
          COALESCE(p.name, 'Unknown Player') AS name,
@@ -9,6 +14,17 @@ const SQL_REBUILD_PLAYER_STATS = `
          COALESCE(p.vproattr, '{}'::text) AS vproattr,
          COALESCE(SUM(pm.goals), 0)::int AS goals,
          COALESCE(SUM(pm.assists), 0)::int AS assists,
+         COALESCE(SUM(pm.realtimegame), 0)::int AS realtimegame,
+         COALESCE(SUM(pm.shots), 0)::int AS shots,
+         COALESCE(SUM(pm.passesmade), 0)::int AS passesmade,
+         COALESCE(SUM(pm.passattempts), 0)::int AS passattempts,
+         COALESCE(SUM(pm.tacklesmade), 0)::int AS tacklesmade,
+         COALESCE(SUM(pm.tackleattempts), 0)::int AS tackleattempts,
+         COALESCE(SUM(pm.cleansheetsany), 0)::int AS cleansheetsany,
+         COALESCE(SUM(pm.saves), 0)::int AS saves,
+         COALESCE(SUM(pm.goalsconceded), 0)::int AS goalsconceded,
+         COALESCE(AVG(pm.rating), 0)::float AS rating,
+         COALESCE(SUM(pm.mom), 0)::int AS mom,
          NOW()
     FROM public.player_match_stats pm
     LEFT JOIN public.players p
@@ -17,6 +33,17 @@ const SQL_REBUILD_PLAYER_STATS = `
   ON CONFLICT (player_id, club_id) DO UPDATE SET
     goals = EXCLUDED.goals,
     assists = EXCLUDED.assists,
+    realtimegame = EXCLUDED.realtimegame,
+    shots = EXCLUDED.shots,
+    passesmade = EXCLUDED.passesmade,
+    passattempts = EXCLUDED.passattempts,
+    tacklesmade = EXCLUDED.tacklesmade,
+    tackleattempts = EXCLUDED.tackleattempts,
+    cleansheetsany = EXCLUDED.cleansheetsany,
+    saves = EXCLUDED.saves,
+    goalsconceded = EXCLUDED.goalsconceded,
+    rating = EXCLUDED.rating,
+    mom = EXCLUDED.mom,
     last_seen = NOW()
 `;
 

--- a/test/saveEaMatch.test.js
+++ b/test/saveEaMatch.test.js
@@ -45,7 +45,7 @@ test('duplicate saveEaMatch calls do not double-count player stats', async () =>
     if (/INSERT INTO public\.match_participants/i.test(sql)) {
       return { rowCount: 1 };
     }
-    if (/INSERT INTO public\.players \(player_id, club_id, name, position, vproattr, goals, assists, last_seen\)/i.test(sql)) {
+    if (/INSERT INTO public\.players/i.test(sql)) {
       const [pid, cid] = params;
       const key = `${pid}_${cid}`;
       if (!players.has(key)) players.set(key, { goals: 0, assists: 0 });
@@ -112,7 +112,7 @@ test('rebuildPlayerStats recomputes totals matching team goals', async () => {
       teamGoals.set(cid, goals);
       return { rowCount: 1 };
     }
-    if (/INSERT INTO public\.players \(player_id, club_id, name, position, vproattr, goals, assists, last_seen\)/i.test(sql)) {
+    if (/INSERT INTO public\.players/i.test(sql)) {
       if (/SELECT pm\.player_id/i.test(sql)) {
         const totals = {};
         for (const [k, v] of pms) {


### PR DESCRIPTION
## Summary
- add migration and backend support for expanded player metrics (shots, passes, tackles, saves, rating, etc.)
- compute and refresh totals for new stats, including averages
- rebuild script and tests updated for extended player data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae90cf79dc832eb8cc5d24adde0778