### PR TITLE
Make league stats cards compact

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -162,13 +162,12 @@ h2{margin:0 0 10px}
 .form-dot.D{background:#777}
 .form-dot.L{background:#a00}
 .league-table tr.top4{border-left:4px solid #0a0}
-.stat-card{margin-top:12px}
+.stat-card{
+  transform:scale(.7);
+  transform-origin:top left;
+  margin:8px 0
+}
 .leaderboard-row{display:flex;align-items:center;gap:8px;margin-top:6px}
-.mini-card{width:40px;height:56px;flex:0 0 40px}
-.mini-card .player-overall{font-size:14px}
-.mini-card .player-name{font-size:8px}
-.mini-card .player-position{font-size:7px;margin-bottom:4px}
-.mini-card .player-stats{font-size:6px}
 .leaderboard-info{flex:1;min-width:0}
 .leaderboard-info div:first-child{font-weight:600}
 .leaderboard-value{font-weight:700;text-align:right}
@@ -1988,7 +1987,7 @@ function renderStats(players){
       .slice(0,5);
     if (!rows.length) return;
     const card = document.createElement('div');
-    card.className = 'm-card stat-card';
+    card.className = 'm-card';
     card.innerHTML = `<strong>${cat.label}</strong>`;
     const list = document.createElement('div');
     const clubIds = new Set();
@@ -1997,7 +1996,7 @@ function renderStats(players){
       rowDiv.className = 'leaderboard-row';
       rowDiv.dataset.clubId = String(r.p.club_id);
       const cardEl = buildPlayerCard({ name:r.p.name, position:r.p.position, player_id:r.p.player_id }, null);
-      cardEl.classList.add('mini-card');
+      cardEl.classList.add('stat-card');
       rowDiv.appendChild(cardEl);
       const info = document.createElement('div');
       info.className = 'leaderboard-info';


### PR DESCRIPTION
## Summary
- shrink player cards in League Stats view via new `.stat-card` class
- apply `.stat-card` only to League Stats player cards so team/squad cards stay full size

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeb07f5ed4832eb021daa3b2fd2980