### PR TITLE
Limit league standings to 2025 season window

### DIFF
--- a/test/leagueStandingsApi.test.js
+++ b/test/leagueStandingsApi.test.js
@@ -32,7 +32,9 @@ test('serves league standings table', async () => {
   const stub = mock.method(pool, 'query', async (sql, params) => {
     if (/jsonb_object_keys/i.test(sql)) {
       assert.match(sql, /WHERE cid = ANY\(\$1\)/i);
-      assert.deepStrictEqual(params, [['1']]);
+      const start = Date.parse('2025-08-27T23:59:00-07:00');
+      const end = Date.parse('2025-09-03T23:59:00-07:00');
+      assert.deepStrictEqual(params, [['1'], start, end]);
 
       const stats = new Map();
       for (const m of matchRows) {


### PR DESCRIPTION
## Summary
- filter league standing queries to matches between Aug 27 and Sep 3 2025
- restrict rebuildLeagueStandings script to the same date window
- adjust league standings test for new timestamp parameters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afe92a7b7c832eae850ccd835733e9