### PR TITLE
feat: make league season range configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ server, for example:
 LOG_LEVEL=debug node server.js
 ```
 
+## Season Date Range
+
+Endpoints that return league standings or leaderboards only consider matches
+within a specific season window. By default the server uses the current season's
+range, but you can override it with the `LEAGUE_START_MS` and
+`LEAGUE_END_MS` environment variables. Each variable accepts either a Unix
+millisecond timestamp or an ISO date string. For example:
+
+```bash
+LEAGUE_START_MS="2026-08-25T23:59:00-07:00" \
+LEAGUE_END_MS="2026-09-01T23:59:00-07:00" \
+node server.js
+```
+
+Update these variables at the start of each season to adjust the range. The
+`scripts/rebuildLeagueStandings.js` utility honors the same environment
+variables when recomputing standings.
+
 ## Card Assets
 
 Place card frame PNGs in `public/assets/cards/` with the following names:

--- a/scripts/rebuildLeagueStandings.js
+++ b/scripts/rebuildLeagueStandings.js
@@ -1,8 +1,19 @@
 const { q } = require('../services/pgwrap');
 const { checkStatsIntegrity } = require('../services/statsIntegrity');
 
-const LEAGUE_START_MS = Date.parse('2025-08-27T23:59:00-07:00');
-const LEAGUE_END_MS = Date.parse('2025-09-03T23:59:00-07:00');
+function parseDateMs(value, fallback) {
+  const ms = value ? Number(value) || Date.parse(value) : NaN;
+  return Number.isFinite(ms) ? ms : fallback;
+}
+
+const LEAGUE_START_MS = parseDateMs(
+  process.env.LEAGUE_START_MS,
+  Date.parse('2025-08-27T23:59:00-07:00')
+);
+const LEAGUE_END_MS = parseDateMs(
+  process.env.LEAGUE_END_MS,
+  Date.parse('2025-09-03T23:59:00-07:00')
+);
 
 const SQL_COMPUTE = `
   WITH club_match AS (

--- a/server.js
+++ b/server.js
@@ -172,8 +172,22 @@ function clubsForLeague(id) {
 const DEFAULT_LEAGUE_ID = process.env.DEFAULT_LEAGUE_ID || 'UPCL_LEAGUE_2025';
 
 // League standings include only matches within this date range (Unix ms)
-const LEAGUE_START_MS = Date.parse('2025-08-27T23:59:00-07:00');
-const LEAGUE_END_MS = Date.parse('2025-09-03T23:59:00-07:00');
+// Defaults reflect the current season but can be overridden via environment
+// variables. Values may be provided as Unix millisecond timestamps or ISO
+// date strings.
+function parseDateMs(value, fallback) {
+  const ms = value ? Number(value) || Date.parse(value) : NaN;
+  return Number.isFinite(ms) ? ms : fallback;
+}
+
+const LEAGUE_START_MS = parseDateMs(
+  process.env.LEAGUE_START_MS,
+  Date.parse('2025-08-27T23:59:00-07:00')
+);
+const LEAGUE_END_MS = parseDateMs(
+  process.env.LEAGUE_END_MS,
+  Date.parse('2025-09-03T23:59:00-07:00')
+);
 
 function resolveClubIds() {
   let ids = clubsForLeague(DEFAULT_LEAGUE_ID);

--- a/test/leagueLeadersApi.test.js
+++ b/test/leagueLeadersApi.test.js
@@ -5,6 +5,11 @@ const path = require('path');
 process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
 process.env.LEAGUE_CLUBS_PATH = path.join(__dirname, 'fixtures', 'leagueClubs.json');
 process.env.DEFAULT_LEAGUE_ID = 'test';
+// Override league range to ensure server reads from environment variables
+const LEAGUE_START_MS = 123456;
+const LEAGUE_END_MS = 789012;
+process.env.LEAGUE_START_MS = String(LEAGUE_START_MS);
+process.env.LEAGUE_END_MS = String(LEAGUE_END_MS);
 
 const { pool } = require('../db');
 
@@ -22,8 +27,6 @@ async function withServer(fn) {
 test('serves league leaders', async () => {
   const scorerRows = [{ club_id: '1', name: 'Alice', count: 3 }];
   const assisterRows = [{ club_id: '1', name: 'Bob', count: 5 }];
-  const LEAGUE_START_MS = Date.parse('2025-08-27T23:59:00-07:00');
-  const LEAGUE_END_MS = Date.parse('2025-09-03T23:59:00-07:00');
 
   const stub = mock.method(pool, 'query', async (sql, params) => {
     if (/SUM\(pms\.goals\)/i.test(sql)) {


### PR DESCRIPTION
## Summary
- allow overriding league date window via LEAGUE_START_MS and LEAGUE_END_MS env vars
- update rebuildLeagueStandings script and tests to respect these env vars
- document how to adjust the range for future seasons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a2488fbc832e8a387e245fa8ac64