### PR TITLE
Define league season window

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,7 @@
 # Sample environment configuration
 # Comma-separated list of default EA club IDs used by /api/players when no clubId is provided
 LEAGUE_CLUB_IDS=
+
+# League season window in Unix milliseconds (UTC)
+LEAGUE_START_MS=1722470400000
+LEAGUE_END_MS=1751327999000


### PR DESCRIPTION
## Summary
- add environment variables for league season window

## Testing
- `npm test`
- `LEAGUE_START_MS=1722470400000 LEAGUE_END_MS=1751327999000 node scripts/rebuildLeagueStandings.js` *(fails: DATABASE_URL not set)*
- `curl -s -D - http://localhost:3000/api/league` *(fails: Failed to fetch standings)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a7942738832eab6a96e8a5ad98e9