### PR TITLE
Use materialized view for league standings

### DIFF
--- a/test/leagueStandingsApi.test.js
+++ b/test/leagueStandingsApi.test.js
@@ -21,10 +21,8 @@ async function withServer(fn) {
 
 test('serves league standings table', async () => {
   const stub = mock.method(pool, 'query', async (sql, params) => {
-    if (/match_participants/i.test(sql)) {
-      const start = Date.parse('2025-08-27T23:59:00-07:00');
-      const end = Date.parse('2025-09-03T23:59:00-07:00');
-      assert.deepStrictEqual(params, [['1'], start, end]);
+    if (/mv_league_standings/i.test(sql)) {
+      assert.deepStrictEqual(params, [['1']]);
       return {
         rows: [
           {

--- a/test/leagues.test.js
+++ b/test/leagues.test.js
@@ -20,7 +20,7 @@ async function withServer(fn) {
 
 test('serves league standings', async () => {
   const stub = mock.method(pool, 'query', async sql => {
-    if (/match_participants/i.test(sql)) {
+    if (/mv_league_standings/i.test(sql)) {
       return {
         rows: [
           {
@@ -65,7 +65,7 @@ test('serves league standings', async () => {
 
 test('standings include teams with zero matches', async () => {
   const stub = mock.method(pool, 'query', async sql => {
-    if (/match_participants/i.test(sql)) {
+    if (/mv_league_standings/i.test(sql)) {
       return {
         rows: [
           {
@@ -110,11 +110,7 @@ test('standings include teams with zero matches', async () => {
 
 test('standings include matches against non-league opponents', async () => {
   const stub = mock.method(pool, 'query', async sql => {
-    if (/home\.club_id\s*=\s*ANY\(\$1\)\s+OR\s+away\.club_id\s*=\s*ANY\(\$1\)/i.test(sql)) {
-      assert.match(
-        sql,
-        /home\.club_id\s*=\s*ANY\(\$1\)\s+OR\s+away\.club_id\s*=\s*ANY\(\$1\)/i
-      );
+    if (/mv_league_standings/i.test(sql)) {
       return {
         rows: [
           {
@@ -228,7 +224,7 @@ test('serves league matches including non-league opponents', async () => {
 
 test('different leagueIds return appropriate clubs', async () => {
   const stub = mock.method(pool, 'query', async (sql, params) => {
-    if (/match_participants/i.test(sql)) {
+    if (/mv_league_standings/i.test(sql)) {
       if (!params) return { rows: [] };
       const cid = params[0][0];
       return {


### PR DESCRIPTION
## Summary
- Read league standings from `mv_league_standings` view
- Refresh materialized standings view when syncing matches
- Update league endpoints and tests for new standings source

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0bb403898832ebf161d4abb4c50c8