### PR TITLE
Replace upcl_leaders materialized view with table

### DIFF
--- a/migrations/upcl_leaders.sql
+++ b/migrations/upcl_leaders.sql
@@ -1,41 +1,10 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS public.upcl_leaders AS
-WITH league_players AS (
-  SELECT pms.club_id,
-         p.name,
-         SUM(pms.goals)   AS goals,
-         SUM(pms.assists) AS assists
-    FROM public.player_match_stats pms
-    JOIN public.matches m
-      ON m.match_id = pms.match_id
-    JOIN public.players p
-      ON p.player_id = pms.player_id
-    JOIN public.upcl_standings s
-      ON s.club_id = pms.club_id
-   WHERE m.ts_ms BETWEEN $league_start AND $league_end
-   GROUP BY pms.club_id, pms.player_id, p.name
-),
-scorers AS (
-  SELECT 'scorer'::text AS type,
-         club_id,
-         name,
-         goals AS count,
-         ROW_NUMBER() OVER (ORDER BY goals DESC, name) AS rn
-    FROM league_players
-   WHERE goals > 0
-),
-assisters AS (
-  SELECT 'assister'::text AS type,
-         club_id,
-         name,
-         assists AS count,
-         ROW_NUMBER() OVER (ORDER BY assists DESC, name) AS rn
-    FROM league_players
-   WHERE assists > 0
-)
-SELECT type, club_id, name, count
-  FROM (
-    SELECT type, club_id, name, count, rn FROM scorers WHERE rn <= 10
-    UNION ALL
-    SELECT type, club_id, name, count, rn FROM assisters WHERE rn <= 10
-  ) AS leaders
- ORDER BY type, count DESC, name;
+DROP MATERIALIZED VIEW IF EXISTS public.upcl_leaders;
+
+CREATE TABLE IF NOT EXISTS public.upcl_leaders (
+  type    TEXT NOT NULL,
+  club_id TEXT NOT NULL,
+  name    TEXT NOT NULL,
+  count   INT  NOT NULL,
+  PRIMARY KEY (type, club_id, name)
+);
+

--- a/scripts/rebuildUpclLeaders.js
+++ b/scripts/rebuildUpclLeaders.js
@@ -1,0 +1,75 @@
+const { q } = require('../services/pgwrap');
+
+function parseDateMs(value, fallback) {
+  const ms = value ? Number(value) || Date.parse(value) : NaN;
+  return Number.isFinite(ms) ? ms : fallback;
+}
+
+const LEAGUE_START_MS = parseDateMs(
+  process.env.LEAGUE_START_MS,
+  Date.parse('2025-08-27T23:59:00-07:00')
+);
+const LEAGUE_END_MS = parseDateMs(
+  process.env.LEAGUE_END_MS,
+  Date.parse('2025-09-03T23:59:00-07:00')
+);
+
+const SQL_LEADERS = `
+  WITH league_players AS (
+    SELECT pms.club_id,
+           p.name,
+           SUM(pms.goals)   AS goals,
+           SUM(pms.assists) AS assists
+      FROM public.player_match_stats pms
+      JOIN public.matches m ON m.match_id = pms.match_id
+      JOIN public.players p ON p.player_id = pms.player_id
+      JOIN public.upcl_standings s ON s.club_id = pms.club_id
+     WHERE m.ts_ms BETWEEN $1 AND $2
+     GROUP BY pms.club_id, pms.player_id, p.name
+  ),
+  scorers AS (
+    SELECT 'scorer'::text AS type,
+           club_id,
+           name,
+           goals AS count,
+           ROW_NUMBER() OVER (ORDER BY goals DESC, name) AS rn
+      FROM league_players
+     WHERE goals > 0
+  ),
+  assisters AS (
+    SELECT 'assister'::text AS type,
+           club_id,
+           name,
+           assists AS count,
+           ROW_NUMBER() OVER (ORDER BY assists DESC, name) AS rn
+      FROM league_players
+     WHERE assists > 0
+  )
+  SELECT type, club_id, name, count
+    FROM (
+      SELECT type, club_id, name, count, rn FROM scorers WHERE rn <= 10
+      UNION ALL
+      SELECT type, club_id, name, count, rn FROM assisters WHERE rn <= 10
+    ) AS leaders
+  ORDER BY type, count DESC, name;
+`;
+
+async function rebuildUpclLeaders() {
+  await q('TRUNCATE TABLE public.upcl_leaders');
+  await q(
+    'INSERT INTO public.upcl_leaders (type, club_id, name, count) ' + SQL_LEADERS,
+    [LEAGUE_START_MS, LEAGUE_END_MS]
+  );
+}
+
+module.exports = { rebuildUpclLeaders };
+
+if (require.main === module) {
+  rebuildUpclLeaders()
+    .then(() => process.exit(0))
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+}
+

--- a/server.js
+++ b/server.js
@@ -25,6 +25,7 @@ const { q } = require('./services/pgwrap');
 const { runMigrations } = require('./services/migrate');
 const { parseVpro, tierFromStats } = require('./services/playerCards');
 const { rebuildUpclStandings } = require('./scripts/rebuildUpclStandings');
+const { rebuildUpclLeaders } = require('./scripts/rebuildUpclLeaders');
 
 // SQL statements for saving EA matches
 const SQL_INSERT_MATCH = `
@@ -361,7 +362,7 @@ async function refreshAllMatches(clubIds) {
   }
   await q('REFRESH MATERIALIZED VIEW CONCURRENTLY public.mv_league_standings');
   await rebuildUpclStandings();
-  await q('REFRESH MATERIALIZED VIEW public.upcl_leaders');
+  await rebuildUpclLeaders();
 }
 
 async function ensureLeagueClubs(clubIds) {


### PR DESCRIPTION
## Summary
- replace the upcl_leaders materialized view with a standard table and drop any existing view
- add a rebuildUpclLeaders script to repopulate the table from match stats
- refreshAllMatches now rebuilds upcl leaders via the new script instead of refreshing a view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0ca3397c0832e8dcde607552ce104