### PR TITLE
Add Home dashboard with league and news summary

### DIFF
--- a/public/js/home.js
+++ b/public/js/home.js
@@ -1,0 +1,81 @@
+async function loadHome(){
+  const motdEl = document.getElementById('homeMotd');
+  const newsEl = document.getElementById('homeNews');
+  const clubsEl = document.getElementById('homeClubs');
+  const standingsEl = document.getElementById('homeStandings');
+  const scorersEl = document.getElementById('homeScorers');
+  try {
+    const [leagueRes, leadersRes, matchesRes, newsRes] = await Promise.all([
+      apiGet('/api/league').catch(()=>({ standings: [] })),
+      apiGet('/api/league/leaders').catch(()=>({ scorers: [] })),
+      apiGet('/api/matches').catch(()=>({ matches: [] })),
+      apiGet('/api/news').catch(()=>({ items: [] }))
+    ]);
+    renderHomeStandings(leagueRes.standings || []);
+    renderHomeScorers(leadersRes.scorers || []);
+    const match = (matchesRes.matches || [])[0];
+    renderHomeMatch(match);
+    renderHomeNews(newsRes.items || []);
+    renderFeaturedClubs(leagueRes.standings || []);
+  } catch (e) {
+    if (motdEl) motdEl.textContent = 'Failed to load.';
+  }
+}
+
+function renderHomeMatch(m){
+  const el = document.getElementById('homeMotd');
+  if(!el) return;
+  if(!m){ el.innerHTML = '<div class="muted">No match data.</div>'; return; }
+  const ids = Object.keys(m.clubs || {});
+  if(ids.length < 2){ el.innerHTML = '<div class="muted">No match data.</div>'; return; }
+  const [a,b] = ids;
+  const A = m.clubs[a];
+  const B = m.clubs[b];
+  const an = byId(a)?.name || A.details?.name || a;
+  const bn = byId(b)?.name || B.details?.name || b;
+  const score = `${A.goals}–${B.goals}`;
+  el.innerHTML = `<div class="fx-vs"><span class="fx-team"><img src="${teamLogoUrl(byId(a))}" alt=""><span>${escapeHtml(an)}</span></span><span class="muted">${score}</span><span class="fx-team"><img src="${teamLogoUrl(byId(b))}" alt=""><span>${escapeHtml(bn)}</span></span></div>`;
+}
+
+function renderHomeNews(items){
+  const wrap = document.getElementById('homeNews');
+  if(!wrap) return;
+  wrap.innerHTML = items.slice(0,3).map(renderNewsItem).join('') || '<div class="muted">No news yet.</div>';
+}
+
+function renderFeaturedClubs(standings){
+  const el = document.getElementById('homeClubs');
+  if(!el) return;
+  const top = standings.slice(0,3);
+  el.innerHTML = top.map(r=>{
+    const club = byId(r.club_id);
+    return `<div class="team-card" data-club-id="${club?.id || r.club_id}"><img class="team-logo" src="${teamLogoUrl(club)}" alt="${escapeHtml(club?.name || r.club_id)} logo"><div class="team-meta"><div class="name">${escapeHtml(club?.name || r.club_id)}</div></div></div>`;
+  }).join('') || '<div class="muted">No clubs.</div>';
+}
+
+function renderHomeStandings(rows){
+  const el = document.getElementById('homeStandings');
+  if(!el) return;
+  if(!rows.length){ el.innerHTML = '<div class="muted">No standings.</div>'; return; }
+  const sorted = [...rows].sort((a,b)=>{
+    if(b.points !== a.points) return b.points - a.points;
+    if(b.goals_for !== a.goals_for) return b.goals_for - a.goals_for;
+    return a.goals_against - b.goals_against;
+  }).slice(0,5);
+  const body = sorted.map((r,i)=>`<tr><td>${i+1}</td><td>${escapeHtml(byId(r.club_id)?.name || r.club_id)}</td><td>${r.wins}</td><td>${r.draws}</td><td>${r.losses}</td><td>${r.points}</td></tr>`).join('');
+  el.innerHTML = `<table class="league-table"><thead><tr><th>#</th><th>Club</th><th>W</th><th>D</th><th>L</th><th>Pts</th></tr></thead><tbody>${body}</tbody></table>`;
+}
+
+function renderHomeScorers(rows){
+  const el = document.getElementById('homeScorers');
+  if(!el) return;
+  if(!rows.length){ el.innerHTML = '<div class="muted">No data.</div>'; return; }
+  const top = rows.slice(0,5);
+  const clubIds = new Set();
+  el.innerHTML = top.map(r=>{
+    clubIds.add(r.club_id);
+    const clubName = byId(r.club_id)?.name || r.club_id;
+    return `<div class="stats-row" data-club-id="${r.club_id}"><img class="player-kit" src="/assets/silhouette.png" alt=""><div class="info"><div>${escapeHtml(r.name)}</div><div class="muted">${escapeHtml(clubName)}</div></div><div class="value">${r.count}</div></div>`;
+  }).join('');
+  clubIds.forEach(cid => renderClubKits(cid, el));
+}

--- a/public/teams.html
+++ b/public/teams.html
@@ -51,6 +51,9 @@ h2{margin:0 0 10px}
 .center{text-align:center}
 .chip{background:#220000;border:1px solid #440000;border-radius:999px;padding:4px 8px;font-size:12px}
 
+/* Home section */
+.home-grid{display:grid;gap:16px;margin-top:18px;grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
+
 /* Teams grid/cards */
 .teams-grid{
   display:grid;grid-template-columns:repeat(auto-fill,minmax(230px,1fr));
@@ -248,6 +251,7 @@ h2{margin:0 0 10px}
 <header>
   <h1>UPCL</h1>
   <div class="navbar" aria-label="Primary">
+    <button id="navHome" data-view="home" aria-pressed="false">Home</button>
     <button id="navTeams"    aria-pressed="true">Teams</button>
     <button id="navNews"     aria-pressed="false">News</button>
     <button id="navMarket"   aria-pressed="false">Market</button>
@@ -263,6 +267,30 @@ h2{margin:0 0 10px}
 </header>
 
 <main>
+  <section id="home" class="tab-content" style="display:none">
+    <div class="home-grid">
+      <div class="m-card">
+        <strong>Match of the Day</strong>
+        <div id="homeMotd" class="muted" style="margin-top:6px">Loading…</div>
+      </div>
+      <div class="m-card">
+        <strong>Latest News</strong>
+        <div id="homeNews" class="news-wrap" style="margin-top:6px"><div class="muted">Loading…</div></div>
+      </div>
+      <div class="m-card">
+        <strong>Featured Clubs</strong>
+        <div id="homeClubs" class="teams-grid" style="margin-top:6px"></div>
+      </div>
+      <div class="m-card">
+        <strong>League Standings</strong>
+        <div id="homeStandings" class="muted" style="margin-top:6px">Loading…</div>
+      </div>
+      <div class="m-card">
+        <strong>Top Scorers</strong>
+        <div id="homeScorers" class="muted" style="margin-top:6px">Loading…</div>
+      </div>
+    </div>
+  </section>
   <!-- TEAMS -->
   <section id="teams-view" aria-live="polite" class="tab-content">
     <div style="display:flex;align-items:center;justify-content:space-between;">
@@ -636,6 +664,7 @@ h2{margin:0 0 10px}
   </div>
 </div>
 
+<script src="js/home.js"></script>
 <script>
 // =======================
 //   CONFIG / CONSTANTS
@@ -729,6 +758,7 @@ async function resolvePlayerName(id){
 }
 
 // nav elements
+const navHome     = document.getElementById('navHome');
 const navTeams    = document.getElementById('navTeams');
 const navNews     = document.getElementById('navNews');
 const navMarket   = document.getElementById('navMarket');
@@ -738,6 +768,7 @@ const navChampions= document.getElementById('navChampions');
 const navLeague   = document.getElementById('navLeague');
 const navFriendlies = document.getElementById('navFriendlies');
 
+const homeView    = document.getElementById('home');
 const teamsViewEl = document.getElementById('teams-view');
 const newsView    = document.getElementById('news-view');
 const marketView  = document.getElementById('market-view');
@@ -751,6 +782,7 @@ function setNav(active){
   if (active==='fixturesSched' && !(isMgr || isAdmin)) { alert('Managers only'); active='fixturesPublic'; }
   document.querySelectorAll('.tab-content').forEach(el=>el.style.display='none');
   const s = {
+    home:[homeView, navHome],
     teams:[teamsViewEl, navTeams],
     news:[newsView, navNews],
     market:[marketView, navMarket],
@@ -767,6 +799,7 @@ function setNav(active){
     btn.setAttribute('aria-pressed', String(is));
   }
 }
+navHome.onclick        = async ()=>{ setNav('home'); await loadHome(); };
 navTeams.onclick       = ()=> setNav('teams');
 navNews.onclick        = async ()=>{ setNav('news'); await loadNews(); };
 navMarket.onclick      = ()=> setNav('market');
@@ -2207,6 +2240,7 @@ async function init(){
   await loadPlayers();
   await checkAdmin();
   await checkMe();
+  await loadHome();
 
   // default
   setNav('teams');


### PR DESCRIPTION
## Summary
- Add responsive Home section with match of the day, news, featured clubs, standings, and top scorers blocks
- Extend navigation and view-switching logic to include Home tab
- Implement `home.js` to fetch league standings, leaders, matches, and news for Home view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be1cc25c48832eb64ebde2cd082802