### PR TITLE
Use teamsGrid reference for team view toggling

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -1013,7 +1013,7 @@ async function upgradeClubPlayers(clubId, container){
   }
 }
 async function openTeamView(clubId){
-  document.querySelector('.teams-grid').style.display = 'none';
+  teamsGrid.style.display = 'none';
   const teamView = document.getElementById('teamView');
   teamView.style.display = 'block';
   const team = byId(clubId);
@@ -1044,7 +1044,7 @@ async function openTeamView(clubId){
 
 function closeTeamView(){
   document.getElementById('teamView').style.display = 'none';
-  document.querySelector('.teams-grid').style.display = 'grid';
+  teamsGrid.style.display = 'grid';
 }
 
 


### PR DESCRIPTION
## Summary
- hide the teams grid via the existing teamsGrid reference when opening a club view
- restore the grid using the same cached element when closing the club view

## Testing
- Manual browser test: open /teams.html, click a team card to reveal its detail view, then click Back to restore the grid

------
https://chatgpt.com/codex/tasks/task_e_68db02ec34cc832e8727f40f62206f1a