### PR TITLE
Add season reset utility and admin endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,26 @@ Update these variables at the start of each season to adjust the range. Use
 `scripts/rebuildLeagueStandings.js` to refresh the `mv_league_standings`
 materialized view.
 
+## Resetting a Season
+
+The `scripts/resetSeason.js` helper clears stored match data and zeros player
+totals. Run it manually with:
+
+```bash
+node scripts/resetSeason.js
+```
+
+The server also exposes an admin-only endpoint to perform the same workflow:
+
+```
+POST /api/admin/reset-season
+```
+
+This route accepts either an authenticated admin session created via
+`POST /api/admin/login` or an `x-admin-token` header that matches the
+`ADMIN_TOKEN` environment variable. Ensure `ADMIN_PASSWORD`, `SESSION_SECRET`,
+and (optionally) `ADMIN_TOKEN` are configured before invoking the reset.
+
 ## Card Assets
 
 Place card frame PNGs in `public/assets/cards/` with the following names:

--- a/scripts/resetSeason.js
+++ b/scripts/resetSeason.js
@@ -1,0 +1,42 @@
+const { q } = require('../services/pgwrap');
+const { rebuildUpclStandings } = require('./rebuildUpclStandings');
+const { rebuildUpclLeaders } = require('./rebuildUpclLeaders');
+
+async function resetSeason() {
+  await q('TRUNCATE TABLE public.matches CASCADE');
+  await q('TRUNCATE TABLE public.player_match_stats');
+  await q('TRUNCATE TABLE public.upcl_leaders');
+  await q('TRUNCATE TABLE public.upcl_standings');
+
+  await q(`
+    UPDATE public.players SET
+      goals = 0,
+      assists = 0,
+      realtimegame = 0,
+      shots = 0,
+      passesmade = 0,
+      passattempts = 0,
+      tacklesmade = 0,
+      tackleattempts = 0,
+      cleansheetsany = 0,
+      saves = 0,
+      goalsconceded = 0,
+      rating = 0,
+      mom = 0
+  `);
+
+  await q('REFRESH MATERIALIZED VIEW public.mv_league_standings');
+  await rebuildUpclStandings();
+  await rebuildUpclLeaders();
+}
+
+module.exports = { resetSeason };
+
+if (require.main === module) {
+  resetSeason()
+    .then(() => process.exit(0))
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/server.js
+++ b/server.js
@@ -26,6 +26,7 @@ const { runMigrations } = require('./services/migrate');
 const { parseVpro, tierFromStats } = require('./services/playerCards');
 const { rebuildUpclStandings } = require('./scripts/rebuildUpclStandings');
 const { rebuildUpclLeaders } = require('./scripts/rebuildUpclLeaders');
+const { resetSeason } = require('./scripts/resetSeason');
 
 // SQL statements for saving EA matches
 const SQL_INSERT_MATCH = `
@@ -437,6 +438,22 @@ app.post('/api/admin/logout', (req, res) => {
 
 app.get('/api/admin/me', (req, res) => {
   res.json({ admin: !!req.session?.isAdmin });
+});
+
+app.post('/api/admin/reset-season', async (req, res) => {
+  const isSessionAdmin = !!req.session?.isAdmin;
+  const hasToken = ADMIN_TOKEN && req.get('x-admin-token') === ADMIN_TOKEN;
+  if (!isSessionAdmin && !hasToken) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  try {
+    await resetSeason();
+    res.json({ ok: true });
+  } catch (err) {
+    logger.error({ err }, 'Failed resetting season');
+    res.status(500).json({ error: 'Failed to reset season' });
+  }
 });
 
 app.post('/admin/migrate', async (req, res) => {


### PR DESCRIPTION
## Summary
- add a resetSeason script to clear match data and rebuild derived tables
- expose an admin-only POST /api/admin/reset-season handler that invokes the helper
- document the reset workflow and required environment variables in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db0b048d98832e8e631e4ef4610326