### PR TITLE
Cast league leader club filters to text array

### DIFF
--- a/server.js
+++ b/server.js
@@ -770,7 +770,7 @@ app.get('/api/league/leaders', async (_req, res) => {
       FROM public.player_match_stats pms
       JOIN public.matches m ON m.match_id = pms.match_id
       JOIN public.players p ON p.player_id = pms.player_id AND p.club_id = pms.club_id
-     WHERE pms.club_id = ANY($1)
+     WHERE pms.club_id = ANY($1::text[])
        AND m.ts_ms BETWEEN $2 AND $3
      GROUP BY pms.club_id, p.name
      ORDER BY count DESC, p.name
@@ -780,7 +780,7 @@ app.get('/api/league/leaders', async (_req, res) => {
       FROM public.player_match_stats pms
       JOIN public.matches m ON m.match_id = pms.match_id
       JOIN public.players p ON p.player_id = pms.player_id AND p.club_id = pms.club_id
-     WHERE pms.club_id = ANY($1)
+     WHERE pms.club_id = ANY($1::text[])
        AND m.ts_ms BETWEEN $2 AND $3
      GROUP BY pms.club_id, p.name
      ORDER BY count DESC, p.name


### PR DESCRIPTION
## Summary
- cast the league leader scorer and assister queries to use text[] club filters so both accept the provided array parameter

## Testing
- npm test -- --test-name-pattern="league leaders"

------
https://chatgpt.com/codex/tasks/task_e_68db18b890e0832e92464708e939cf89