### PR TITLE
Fix league leader club ID filtering for numeric columns

### DIFF
--- a/test/leagueLeadersApi.test.js
+++ b/test/leagueLeadersApi.test.js
@@ -30,11 +30,11 @@ test('serves league leaders', async () => {
 
   const stub = mock.method(pool, 'query', async (sql, params) => {
     if (/SUM\(pms\.goals\)/i.test(sql)) {
-      assert.deepStrictEqual(params, [['1'], LEAGUE_START_MS, LEAGUE_END_MS]);
+      assert.deepStrictEqual(params, [[1], LEAGUE_START_MS, LEAGUE_END_MS]);
       return { rows: scorerRows };
     }
     if (/SUM\(pms\.assists\)/i.test(sql)) {
-      assert.deepStrictEqual(params, [['1'], LEAGUE_START_MS, LEAGUE_END_MS]);
+      assert.deepStrictEqual(params, [[1], LEAGUE_START_MS, LEAGUE_END_MS]);
       return { rows: assisterRows };
     }
     return { rows: [] };

--- a/test/leagueStandingsApi.test.js
+++ b/test/leagueStandingsApi.test.js
@@ -22,11 +22,11 @@ async function withServer(fn) {
 test('serves league standings table', async () => {
   const stub = mock.method(pool, 'query', async (sql, params) => {
     if (/mv_league_standings/i.test(sql)) {
-      assert.deepStrictEqual(params, [['1']]);
+      assert.deepStrictEqual(params, [[1]]);
       return {
         rows: [
           {
-            club_id: '1',
+            club_id: 1,
             played: 1,
             wins: 0,
             draws: 0,
@@ -48,7 +48,7 @@ test('serves league standings table', async () => {
     assert.deepStrictEqual(body, {
       standings: [
         {
-          club_id: '1',
+          club_id: 1,
           played: 1,
           wins: 0,
           draws: 0,

--- a/test/leagues.test.js
+++ b/test/leagues.test.js
@@ -24,7 +24,7 @@ test('serves league standings', async () => {
       return {
         rows: [
           {
-            club_id: '1',
+            club_id: 1,
             played: 1,
             wins: 1,
             draws: 0,
@@ -38,7 +38,7 @@ test('serves league standings', async () => {
       };
     }
     if (/from\s+public\.clubs/i.test(sql)) {
-      return { rows: [ { id: '1', name: 'Team 1' } ] };
+      return { rows: [ { id: 1, name: 'Team 1' } ] };
     }
     return { rows: [] };
   });
@@ -46,9 +46,9 @@ test('serves league standings', async () => {
   await withServer(async port => {
     const res = await fetch(`http://localhost:${port}/api/leagues/test`);
     const body = await res.json();
-    assert.deepStrictEqual(body.teams, [ { id: '1', name: 'Team 1' } ]);
+    assert.deepStrictEqual(body.teams, [ { id: 1, name: 'Team 1' } ]);
     assert.deepStrictEqual(body.standings, [ {
-      club_id: '1',
+      club_id: 1,
       played: 1,
       wins: 1,
       draws: 0,
@@ -69,7 +69,7 @@ test('standings include teams with zero matches', async () => {
       return {
         rows: [
           {
-            club_id: '1',
+            club_id: 1,
             played: 0,
             wins: 0,
             draws: 0,
@@ -83,7 +83,7 @@ test('standings include teams with zero matches', async () => {
       };
     }
     if (/from\s+public\.clubs/i.test(sql)) {
-      return { rows: [ { id: '1', name: 'Team 1' } ] };
+      return { rows: [ { id: 1, name: 'Team 1' } ] };
     }
     return { rows: [] };
   });
@@ -92,7 +92,7 @@ test('standings include teams with zero matches', async () => {
     const res = await fetch(`http://localhost:${port}/api/leagues/test`);
     const body = await res.json();
     assert.deepStrictEqual(body.standings, [ {
-      club_id: '1',
+      club_id: 1,
       played: 0,
       wins: 0,
       draws: 0,
@@ -102,7 +102,7 @@ test('standings include teams with zero matches', async () => {
       goal_diff: 0,
       points: 0,
     } ]);
-    assert.deepStrictEqual(body.teams, [ { id: '1', name: 'Team 1' } ]);
+    assert.deepStrictEqual(body.teams, [ { id: 1, name: 'Team 1' } ]);
   });
 
   stub.mock.restore();
@@ -114,7 +114,7 @@ test('standings include matches against non-league opponents', async () => {
       return {
         rows: [
           {
-            club_id: '1',
+            club_id: 1,
             played: 1,
             wins: 0,
             draws: 0,
@@ -128,7 +128,7 @@ test('standings include matches against non-league opponents', async () => {
       };
     }
     if (/from\s+public\.clubs/i.test(sql)) {
-      return { rows: [ { id: '1', name: 'Team 1' } ] };
+      return { rows: [ { id: 1, name: 'Team 1' } ] };
     }
     return { rows: [] };
   });
@@ -138,7 +138,7 @@ test('standings include matches against non-league opponents', async () => {
     const body = await res.json();
     assert.deepStrictEqual(body.standings, [
       {
-        club_id: '1',
+        club_id: 1,
         played: 1,
         wins: 0,
         draws: 0,
@@ -254,9 +254,9 @@ test('different leagueIds return appropriate clubs', async () => {
   await withServer(async port => {
     let res = await fetch(`http://localhost:${port}/api/leagues/alpha`);
     let body = await res.json();
-    assert.deepStrictEqual(body.teams, [ { id: '1', name: 'Team 1' } ]);
+    assert.deepStrictEqual(body.teams, [ { id: 1, name: 'Team 1' } ]);
     assert.deepStrictEqual(body.standings, [ {
-      club_id: '1',
+      club_id: 1,
       played: 1,
       wins: 1,
       draws: 0,
@@ -269,9 +269,9 @@ test('different leagueIds return appropriate clubs', async () => {
 
     res = await fetch(`http://localhost:${port}/api/leagues/beta`);
     body = await res.json();
-    assert.deepStrictEqual(body.teams, [ { id: '2', name: 'Team 2' } ]);
+    assert.deepStrictEqual(body.teams, [ { id: 2, name: 'Team 2' } ]);
     assert.deepStrictEqual(body.standings, [ {
-      club_id: '2',
+      club_id: 2,
       played: 1,
       wins: 1,
       draws: 0,


### PR DESCRIPTION
## Summary
- normalize configured club IDs so numeric arrays are passed into database queries
- remove the text[] coercion from league leader SQL filters so numeric club_id columns are supported
- adjust league tests to expect numeric club identifiers in query parameters and responses

## Testing
- npm test -- test/leagueLeadersApi.test.js
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db1c7203bc832e9514555e2e05eb67