### PR TITLE
Cast club ID arrays to bigint for league queries

### DIFF
--- a/server.js
+++ b/server.js
@@ -759,18 +759,18 @@ const SQL_LEAGUE_STANDINGS = `
          goal_diff,
          points
     FROM public.mv_league_standings
-   WHERE club_id = ANY($1)
+   WHERE club_id = ANY($1::bigint[])
    ORDER BY points DESC, goal_diff DESC, goals_for DESC`;
 
 const SQL_LEAGUE_TEAMS = `
   SELECT club_id AS "id", club_name AS "name"
     FROM public.clubs
-   WHERE club_id = ANY($1)`;
+   WHERE club_id = ANY($1::bigint[])`;
 
 async function getUpclLeaders(clubIds) {
   const sql = `SELECT type, club_id AS "clubId", name, count
                  FROM public.upcl_leaders
-                WHERE club_id = ANY($1)
+                WHERE club_id = ANY($1::bigint[])
                 ORDER BY type, count DESC, name`;
   const { rows } = await q(sql, [clubIds]);
   return {
@@ -801,7 +801,7 @@ app.get('/api/league/leaders', async (_req, res) => {
       FROM public.player_match_stats pms
       JOIN public.matches m ON m.match_id = pms.match_id
       JOIN public.players p ON p.player_id = pms.player_id AND p.club_id = pms.club_id
-     WHERE pms.club_id = ANY($1)
+     WHERE pms.club_id = ANY($1::bigint[])
        AND m.ts_ms BETWEEN $2 AND $3
      GROUP BY pms.club_id, p.name
      ORDER BY count DESC, p.name
@@ -811,7 +811,7 @@ app.get('/api/league/leaders', async (_req, res) => {
       FROM public.player_match_stats pms
       JOIN public.matches m ON m.match_id = pms.match_id
       JOIN public.players p ON p.player_id = pms.player_id AND p.club_id = pms.club_id
-     WHERE pms.club_id = ANY($1)
+     WHERE pms.club_id = ANY($1::bigint[])
        AND m.ts_ms BETWEEN $2 AND $3
      GROUP BY pms.club_id, p.name
      ORDER BY count DESC, p.name

--- a/test/leagueLeadersApi.test.js
+++ b/test/leagueLeadersApi.test.js
@@ -30,10 +30,12 @@ test('serves league leaders', async () => {
 
   const stub = mock.method(pool, 'query', async (sql, params) => {
     if (/SUM\(pms\.goals\)/i.test(sql)) {
+      assert.match(sql, /ANY\(\$1::bigint\[\]\)/i);
       assert.deepStrictEqual(params, [[1], LEAGUE_START_MS, LEAGUE_END_MS]);
       return { rows: scorerRows };
     }
     if (/SUM\(pms\.assists\)/i.test(sql)) {
+      assert.match(sql, /ANY\(\$1::bigint\[\]\)/i);
       assert.deepStrictEqual(params, [[1], LEAGUE_START_MS, LEAGUE_END_MS]);
       return { rows: assisterRows };
     }

--- a/test/leagueStandingsApi.test.js
+++ b/test/leagueStandingsApi.test.js
@@ -22,6 +22,7 @@ async function withServer(fn) {
 test('serves league standings table', async () => {
   const stub = mock.method(pool, 'query', async (sql, params) => {
     if (/mv_league_standings/i.test(sql)) {
+      assert.match(sql, /ANY\(\$1::bigint\[\]\)/i);
       assert.deepStrictEqual(params, [[1]]);
       return {
         rows: [


### PR DESCRIPTION
## Summary
- cast club ID arrays to bigint[] in league standings and leader queries to avoid type mismatches
- update league API tests to assert the new casts while verifying parameters

## Testing
- npm test -- test/leagueStandingsApi.test.js test/leagueLeadersApi.test.js

------
https://chatgpt.com/codex/tasks/task_e_68db2d6529b4832e9f692783ece9c2f1