### PR TITLE
Align league queries with text club IDs

### DIFF
--- a/server.js
+++ b/server.js
@@ -171,16 +171,15 @@ function normalizeClubIds(ids) {
   if (!Array.isArray(ids) || !ids.length) {
     return [];
   }
-  return ids
-    .map(id => {
-      const asString = String(id ?? '').trim();
-      if (!asString) {
-        return null;
-      }
-      const asNumber = Number(asString);
-      return Number.isFinite(asNumber) ? asNumber : null;
-    })
-    .filter(id => id !== null);
+  const seen = new Set();
+  const normalized = [];
+  for (const id of ids) {
+    const asString = String(id ?? '').trim();
+    if (!asString || seen.has(asString)) continue;
+    seen.add(asString);
+    normalized.push(asString);
+  }
+  return normalized;
 }
 
 function clubsForLeague(id) {
@@ -766,18 +765,18 @@ const SQL_LEAGUE_STANDINGS = `
          goal_diff,
          points
     FROM public.mv_league_standings
-   WHERE club_id = ANY($1::bigint[])
+   WHERE club_id = ANY($1::text[])
    ORDER BY points DESC, goal_diff DESC, goals_for DESC`;
 
 const SQL_LEAGUE_TEAMS = `
   SELECT club_id AS "id", club_name AS "name"
     FROM public.clubs
-   WHERE club_id = ANY($1::bigint[])`;
+   WHERE club_id = ANY($1::text[])`;
 
 async function getUpclLeaders(clubIds) {
   const sql = `SELECT type, club_id AS "clubId", name, count
                  FROM public.upcl_leaders
-                WHERE club_id = ANY($1::bigint[])
+                WHERE club_id = ANY($1::text[])
                 ORDER BY type, count DESC, name`;
   const { rows } = await q(sql, [clubIds]);
   return {
@@ -808,7 +807,7 @@ app.get('/api/league/leaders', async (_req, res) => {
       FROM public.player_match_stats pms
       JOIN public.matches m ON m.match_id = pms.match_id
       JOIN public.players p ON p.player_id = pms.player_id AND p.club_id = pms.club_id
-     WHERE pms.club_id = ANY($1::bigint[])
+     WHERE pms.club_id = ANY($1::text[])
        AND m.ts_ms BETWEEN $2 AND $3
      GROUP BY pms.club_id, p.name
      ORDER BY count DESC, p.name
@@ -818,7 +817,7 @@ app.get('/api/league/leaders', async (_req, res) => {
       FROM public.player_match_stats pms
       JOIN public.matches m ON m.match_id = pms.match_id
       JOIN public.players p ON p.player_id = pms.player_id AND p.club_id = pms.club_id
-     WHERE pms.club_id = ANY($1::bigint[])
+     WHERE pms.club_id = ANY($1::text[])
        AND m.ts_ms BETWEEN $2 AND $3
      GROUP BY pms.club_id, p.name
      ORDER BY count DESC, p.name

--- a/test/leagueLeadersApi.test.js
+++ b/test/leagueLeadersApi.test.js
@@ -30,13 +30,13 @@ test('serves league leaders', async () => {
 
   const stub = mock.method(pool, 'query', async (sql, params) => {
     if (/SUM\(pms\.goals\)/i.test(sql)) {
-      assert.match(sql, /ANY\(\$1::bigint\[\]\)/i);
-      assert.deepStrictEqual(params, [[1], LEAGUE_START_MS, LEAGUE_END_MS]);
+      assert.match(sql, /ANY\(\$1::text\[\]\)/i);
+      assert.deepStrictEqual(params, [['1'], LEAGUE_START_MS, LEAGUE_END_MS]);
       return { rows: scorerRows };
     }
     if (/SUM\(pms\.assists\)/i.test(sql)) {
-      assert.match(sql, /ANY\(\$1::bigint\[\]\)/i);
-      assert.deepStrictEqual(params, [[1], LEAGUE_START_MS, LEAGUE_END_MS]);
+      assert.match(sql, /ANY\(\$1::text\[\]\)/i);
+      assert.deepStrictEqual(params, [['1'], LEAGUE_START_MS, LEAGUE_END_MS]);
       return { rows: assisterRows };
     }
     return { rows: [] };

--- a/test/leagueStandingsApi.test.js
+++ b/test/leagueStandingsApi.test.js
@@ -22,8 +22,8 @@ async function withServer(fn) {
 test('serves league standings table', async () => {
   const stub = mock.method(pool, 'query', async (sql, params) => {
     if (/mv_league_standings/i.test(sql)) {
-      assert.match(sql, /ANY\(\$1::bigint\[\]\)/i);
-      assert.deepStrictEqual(params, [[1]]);
+      assert.match(sql, /ANY\(\$1::text\[\]\)/i);
+      assert.deepStrictEqual(params, [['1']]);
       return {
         rows: [
           {

--- a/test/leagues.test.js
+++ b/test/leagues.test.js
@@ -24,7 +24,7 @@ test('serves league standings', async () => {
       return {
         rows: [
           {
-            club_id: 1,
+            club_id: '1',
             played: 1,
             wins: 1,
             draws: 0,
@@ -38,7 +38,7 @@ test('serves league standings', async () => {
       };
     }
     if (/from\s+public\.clubs/i.test(sql)) {
-      return { rows: [ { id: 1, name: 'Team 1' } ] };
+      return { rows: [ { id: '1', name: 'Team 1' } ] };
     }
     return { rows: [] };
   });
@@ -46,9 +46,9 @@ test('serves league standings', async () => {
   await withServer(async port => {
     const res = await fetch(`http://localhost:${port}/api/leagues/test`);
     const body = await res.json();
-    assert.deepStrictEqual(body.teams, [ { id: 1, name: 'Team 1' } ]);
+    assert.deepStrictEqual(body.teams, [ { id: '1', name: 'Team 1' } ]);
     assert.deepStrictEqual(body.standings, [ {
-      club_id: 1,
+      club_id: '1',
       played: 1,
       wins: 1,
       draws: 0,
@@ -69,7 +69,7 @@ test('standings include teams with zero matches', async () => {
       return {
         rows: [
           {
-            club_id: 1,
+            club_id: '1',
             played: 0,
             wins: 0,
             draws: 0,
@@ -83,7 +83,7 @@ test('standings include teams with zero matches', async () => {
       };
     }
     if (/from\s+public\.clubs/i.test(sql)) {
-      return { rows: [ { id: 1, name: 'Team 1' } ] };
+      return { rows: [ { id: '1', name: 'Team 1' } ] };
     }
     return { rows: [] };
   });
@@ -92,7 +92,7 @@ test('standings include teams with zero matches', async () => {
     const res = await fetch(`http://localhost:${port}/api/leagues/test`);
     const body = await res.json();
     assert.deepStrictEqual(body.standings, [ {
-      club_id: 1,
+      club_id: '1',
       played: 0,
       wins: 0,
       draws: 0,
@@ -102,7 +102,7 @@ test('standings include teams with zero matches', async () => {
       goal_diff: 0,
       points: 0,
     } ]);
-    assert.deepStrictEqual(body.teams, [ { id: 1, name: 'Team 1' } ]);
+    assert.deepStrictEqual(body.teams, [ { id: '1', name: 'Team 1' } ]);
   });
 
   stub.mock.restore();
@@ -114,7 +114,7 @@ test('standings include matches against non-league opponents', async () => {
       return {
         rows: [
           {
-            club_id: 1,
+            club_id: '1',
             played: 1,
             wins: 0,
             draws: 0,
@@ -128,7 +128,7 @@ test('standings include matches against non-league opponents', async () => {
       };
     }
     if (/from\s+public\.clubs/i.test(sql)) {
-      return { rows: [ { id: 1, name: 'Team 1' } ] };
+      return { rows: [ { id: '1', name: 'Team 1' } ] };
     }
     return { rows: [] };
   });
@@ -138,7 +138,7 @@ test('standings include matches against non-league opponents', async () => {
     const body = await res.json();
     assert.deepStrictEqual(body.standings, [
       {
-        club_id: 1,
+        club_id: '1',
         played: 1,
         wins: 0,
         draws: 0,
@@ -254,9 +254,9 @@ test('different leagueIds return appropriate clubs', async () => {
   await withServer(async port => {
     let res = await fetch(`http://localhost:${port}/api/leagues/alpha`);
     let body = await res.json();
-    assert.deepStrictEqual(body.teams, [ { id: 1, name: 'Team 1' } ]);
+    assert.deepStrictEqual(body.teams, [ { id: '1', name: 'Team 1' } ]);
     assert.deepStrictEqual(body.standings, [ {
-      club_id: 1,
+      club_id: '1',
       played: 1,
       wins: 1,
       draws: 0,
@@ -269,9 +269,9 @@ test('different leagueIds return appropriate clubs', async () => {
 
     res = await fetch(`http://localhost:${port}/api/leagues/beta`);
     body = await res.json();
-    assert.deepStrictEqual(body.teams, [ { id: 2, name: 'Team 2' } ]);
+    assert.deepStrictEqual(body.teams, [ { id: '2', name: 'Team 2' } ]);
     assert.deepStrictEqual(body.standings, [ {
-      club_id: 2,
+      club_id: '2',
       played: 1,
       wins: 1,
       draws: 0,


### PR DESCRIPTION
## Summary
- treat club ids as strings when normalizing configuration data to match the database schema
- update league standings and leaders SQL to compare against text arrays
- revise related API tests to assert on string ids and text casts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db319b342c832ea5d309192af8b702