### PR TITLE
Fix teams page glow overflow on small viewports

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -301,12 +301,16 @@ main{
   max-width:1280px;
   margin:0 auto;
   z-index:1;
+  overflow-x:hidden;
 }
 main::before{
   content:"";
   position:absolute;
   inset:0;
-  margin-inline:-10vw;
+  left:50%;
+  right:auto;
+  width:calc(100% + min(20vw, 120px));
+  transform:translateX(-50%);
   background:
     radial-gradient(75% 45% at 50% 0%, rgba(30,201,195,0.18) 0%, transparent 65%),
     linear-gradient(0deg, rgba(255,255,255,0.02), rgba(255,255,255,0));


### PR DESCRIPTION
## Summary
- adjust the teams page background glow pseudo-element so it no longer creates horizontal overflow on narrow screens
- center the glow expansion using a width calculation and hide horizontal overflow on the main container for safety

## Testing
- npm start *(fails: requires DATABASE_URL for database bootstrap)*

------
https://chatgpt.com/codex/tasks/task_e_68db68caef34832e8c20f27548bb5d7f