### PR TITLE
Improve mobile responsiveness for teams and rankings

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -343,6 +343,7 @@ h2{margin:0 0 12px;font-size:28px;letter-spacing:0.08em;text-transform:uppercase
   gap:24px;
   margin-top:28px;
   padding:8px 4px 28px;
+  grid-template-columns:repeat(auto-fill,minmax(260px,1fr));
 }
 .teams-grid::before{
   content:"";
@@ -358,13 +359,15 @@ h2{margin:0 0 12px;font-size:28px;letter-spacing:0.08em;text-transform:uppercase
   z-index:-1;
 }
 .team-card{
-  padding:24px 24px 22px;
+  padding:22px 22px 20px;
   display:flex;
   flex-direction:column;
   gap:16px;
   color:#f6f9ff;
   cursor:pointer;
   transform-style:preserve-3d;
+  border:1px solid rgba(212,175,55,0.18);
+  background:linear-gradient(150deg, rgba(10,15,24,0.92), rgba(3,6,12,0.94));
 }
 .team-card.glow-card:hover,
 .team-card.glow-card:focus-visible{
@@ -384,6 +387,7 @@ h2{margin:0 0 12px;font-size:28px;letter-spacing:0.08em;text-transform:uppercase
   background:linear-gradient(135deg, rgba(17,24,39,0.8), rgba(6,11,17,0.92));
   padding:16px;
   box-shadow:inset 0 0 0 1px rgba(148,163,184,0.25), 0 0 24px rgba(30,201,195,0.18);
+  flex-shrink:0;
 }
 .team-logo{
   width:100%;
@@ -403,6 +407,7 @@ h2{margin:0 0 12px;font-size:28px;letter-spacing:0.08em;text-transform:uppercase
   justify-content:space-between;
   align-items:flex-start;
   gap:12px;
+  flex-wrap:wrap;
 }
 .team-meta .name{
   font-weight:800;
@@ -515,21 +520,81 @@ h2{margin:0 0 12px;font-size:28px;letter-spacing:0.08em;text-transform:uppercase
   color:var(--accent);
   font-size:22px;
 }
-@media (max-width:1024px){
+
+.leaderboard-table tbody tr{
+  border-radius:22px;
+  border:1px solid rgba(212,175,55,0.2);
+  background:linear-gradient(155deg, rgba(12,18,30,0.92), rgba(4,7,14,0.94));
+  box-shadow:0 22px 44px rgba(2,6,12,0.55);
+  transition:transform .25s ease, box-shadow .25s ease, border-color .25s ease, background .25s ease;
+}
+.leaderboard-table tbody tr:hover,
+.leaderboard-table tbody tr:focus-within{
+  transform:translateY(-2px);
+  border-color:rgba(250,204,21,0.45);
+  box-shadow:0 26px 52px rgba(2,6,12,0.6);
+  background:linear-gradient(155deg, rgba(16,24,38,0.95), rgba(6,10,18,0.97));
+}
+.leaderboard-table tbody tr td{
+  background:transparent;
+  border:none;
+}
+.leaderboard-row{ /* utility hook for JS-generated rows */
+  border-radius:22px;
+}
+@media (max-width:1023px){
   header{flex-direction:column;align-items:flex-start;gap:16px;}
   .site-brand::after{display:none;}
   .navbar{width:100%;gap:18px;}
   .nav-group{min-width:0;}
   .nav-group-items{flex-wrap:wrap;gap:6px;}
+  .teams-grid{grid-template-columns:repeat(2,minmax(220px,1fr));gap:20px;}
+  .team-card{padding:20px;}
+  .team-card-header{flex-direction:row;align-items:center;gap:18px;}
+  .team-meta{flex:1;}
+  .team-meta .record{margin-top:0;}
+  .team-crest{padding:14px;}
 }
 @media (max-width:768px){
   .navbar{padding-bottom:2px;}
   .navbar button{padding:8px 14px;font-size:12px;}
-  .team-card{padding:18px;}
-  .team-meta .name{font-size:17px;}
-  .teams-grid{gap:18px;}
-  .team-manager{font-size:12px;}
+  .teams-grid{grid-template-columns:1fr;gap:16px;}
+  .team-card{padding:16px 18px;gap:14px;}
+  .team-card-header{flex-direction:row;align-items:center;gap:16px;}
+  .team-crest{width:92px;padding:12px;}
+  .team-logo{max-width:80px;margin:0 auto;}
+  .team-meta .name{font-size:16px;}
+  .team-meta{gap:6px;}
+  .team-meta .record{font-size:11px;padding:5px 9px;letter-spacing:0.12em;}
+  .team-meta .record{align-self:flex-start;}
+  .team-country{margin-top:4px;font-size:12px;}
+  .jersey-swatches{margin-top:8px;gap:6px;}
+  .jersey-swatch{padding:5px 8px;font-size:10px;}
+  .team-manager{font-size:11px;margin-top:4px;}
+  #rankingsTableWrap{padding-left:1.25rem;padding-right:1.25rem;overflow-x:visible;}
+  .leaderboard-table{border-spacing:0;}
+  .leaderboard-table thead{display:none;}
+  .leaderboard-table tbody{display:flex;flex-direction:column;gap:16px;}
+  .leaderboard-table tbody tr{display:flex;flex-direction:column;padding:18px 16px;gap:8px;}
+  .leaderboard-table tbody tr td{display:flex;align-items:center;justify-content:space-between;gap:12px;width:100%;padding:6px 0;font-size:13px;}
+  .leaderboard-table tbody tr td::before{content:attr(data-label) ': ';font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.18em;color:rgba(250,204,21,0.75);margin-right:12px;flex:0 0 auto;}
+  .leaderboard-table tbody tr td:first-child{padding-top:0;}
+  .leaderboard-table tbody tr td:last-child{padding-bottom:0;}
+  .leaderboard-table tbody tr td > .pointer-events-none{display:none !important;}
   .brand-tagline{letter-spacing:0.24em;font-size:10px;}
+}
+@media (max-width:480px){
+  .team-card{padding:14px 16px;gap:12px;}
+  .team-card-header{gap:14px;}
+  .team-crest{width:78px;padding:10px;}
+  .team-logo{max-width:72px;}
+  .team-meta .name{font-size:15px;}
+  .team-meta .record{font-size:10px;padding:4px 8px;letter-spacing:0.1em;}
+  .team-country{font-size:11px;}
+  .jersey-swatch{padding:4px 7px;font-size:9px;letter-spacing:0.06em;}
+  .leaderboard-table tbody tr{padding:16px 14px;}
+  .leaderboard-table tbody tr td{font-size:12px;gap:10px;}
+  .leaderboard-table tbody tr td::before{font-size:10px;letter-spacing:0.16em;}
 }
 .players-grid {
   display: flex;
@@ -1020,7 +1085,7 @@ h2{margin:0 0 12px;font-size:28px;letter-spacing:0.08em;text-transform:uppercase
         Unable to load player data. Try refreshing in a moment.
       </div>
       <div id="rankingsTableWrap" class="hidden overflow-x-auto px-4 pb-8">
-        <table class="min-w-full border-separate border-spacing-y-3 text-xs text-slate-100 sm:text-sm md:text-base">
+        <table class="leaderboard-table min-w-full border-separate border-spacing-y-3 text-xs text-slate-100 sm:text-sm md:text-base">
           <thead>
             <tr class="text-xs uppercase tracking-[0.32em] text-yellow-200/70">
               <th scope="col" class="px-4 py-3 text-left">Rank</th>
@@ -1572,7 +1637,7 @@ function renderLeaderboard(players){
 
   players.forEach((player, index) => {
     const row = document.createElement('tr');
-    const baseClass = 'group relative overflow-hidden rounded-2xl border bg-slate-950/70 backdrop-blur-sm transition-all duration-300 hover:-translate-y-1 hover:border-yellow-300/60 hover:shadow-[0_18px_35px_rgba(250,204,21,0.25)]';
+    const baseClass = 'group leaderboard-row relative overflow-hidden rounded-2xl border bg-slate-950/70 backdrop-blur-sm transition-all duration-300 hover:-translate-y-1 hover:border-yellow-300/60 hover:shadow-[0_18px_35px_rgba(250,204,21,0.25)]';
     let topClass = 'border-slate-700/60 shadow-[0_10px_25px_rgba(5,6,12,0.65)]';
     if(index === 0){
       topClass = 'border-yellow-300/90 shadow-[0_0_55px_rgba(250,204,21,0.55)]';
@@ -1602,8 +1667,8 @@ function renderLeaderboard(players){
     `;
 
     row.innerHTML = `
-      <td class="px-4 py-3 text-sm font-extrabold tracking-wide text-yellow-200/90">${index + 1}</td>
-      <td class="relative px-4 py-3 text-sm font-semibold text-slate-100">
+      <td data-label="Rank" class="px-4 py-3 text-sm font-extrabold tracking-wide text-yellow-200/90">${index + 1}</td>
+      <td data-label="Player" class="relative px-4 py-3 text-sm font-semibold text-slate-100">
         <div class="flex flex-col gap-1">
           <span>${escapeHtml(player.name)}</span>
           <span class="text-xs font-medium uppercase tracking-[0.24em] text-yellow-200/70">Rating ${player.rating.toFixed(2)} • Win ${player.winRate.toFixed(1)}%</span>
@@ -1612,10 +1677,10 @@ function renderLeaderboard(players){
           ${tooltip}
         </div>
       </td>
-      <td class="px-4 py-3 text-sm font-medium text-slate-200">${escapeHtml(player.clubName)}</td>
-      <td class="px-4 py-3 text-sm font-semibold uppercase tracking-[0.24em] text-yellow-100">${escapeHtml(player.position)}</td>
-      <td class="px-4 py-3 text-sm font-bold text-yellow-200">${formatPoints(player.points)}</td>
-      <td class="px-4 py-3 text-sm font-bold text-yellow-100">${formatUsd(player.value)}</td>
+      <td data-label="Club" class="px-4 py-3 text-sm font-medium text-slate-200">${escapeHtml(player.clubName)}</td>
+      <td data-label="Position" class="px-4 py-3 text-sm font-semibold uppercase tracking-[0.24em] text-yellow-100">${escapeHtml(player.position)}</td>
+      <td data-label="Points" class="px-4 py-3 text-sm font-bold text-yellow-200">${formatPoints(player.points)}</td>
+      <td data-label="Value (USD)" class="px-4 py-3 text-sm font-bold text-yellow-100">${formatUsd(player.value)}</td>
     `;
 
     leaderboardEls.body.appendChild(row);


### PR DESCRIPTION
## Summary
- convert the rankings leaderboard into a stacked card layout on small screens using data-labels for mobile friendly labels
- redesign the team grid and cards to scale down gracefully with responsive spacing, logo sizing, and typography adjustments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc350ae6f0832eb2972febab5f3298