### PR TITLE
Remove date range filter from league leaderboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,20 +32,18 @@ LOG_LEVEL=debug node server.js
 
 ## Season Date Range
 
-Endpoints that return league standings or leaderboards only consider matches
-within a specific season window. By default the server uses the current season's
-range, but you can override it with the `LEAGUE_START_MS` and
-`LEAGUE_END_MS` environment variables. Each variable accepts either a Unix
-millisecond timestamp or an ISO date string. For example:
+When importing fixtures from EA the server ignores matches that occurred before
+`LEAGUE_START_MS`. The default value reflects the current season's opening day,
+but you can override it with an environment variable. The variable accepts
+either a Unix millisecond timestamp or an ISO date string. For example:
 
 ```bash
 LEAGUE_START_MS="2026-08-25T23:59:00-07:00" \
-LEAGUE_END_MS="2026-09-01T23:59:00-07:00" \
 node server.js
 ```
 
-Update these variables at the start of each season to adjust the range. Use
-`scripts/rebuildLeagueStandings.js` to refresh the `mv_league_standings`
+Update this variable at the start of each season to adjust the import window.
+Use `scripts/rebuildLeagueStandings.js` to refresh the `mv_league_standings`
 materialized view.
 
 ## Card Assets

--- a/scripts/rebuildUpclLeaders.js
+++ b/scripts/rebuildUpclLeaders.js
@@ -1,19 +1,5 @@
 const { q } = require('../services/pgwrap');
 
-function parseDateMs(value, fallback) {
-  const ms = value ? Number(value) || Date.parse(value) : NaN;
-  return Number.isFinite(ms) ? ms : fallback;
-}
-
-const LEAGUE_START_MS = parseDateMs(
-  process.env.LEAGUE_START_MS,
-  Date.parse('2025-08-27T23:59:00-07:00')
-);
-const LEAGUE_END_MS = parseDateMs(
-  process.env.LEAGUE_END_MS,
-  Date.parse('2025-09-03T23:59:00-07:00')
-);
-
 const SQL_LEADERS = `
   WITH league_players AS (
     SELECT pms.club_id,
@@ -24,7 +10,6 @@ const SQL_LEADERS = `
       JOIN public.matches m ON m.match_id = pms.match_id
       JOIN public.players p ON p.player_id = pms.player_id
       JOIN public.upcl_standings s ON s.club_id = pms.club_id
-     WHERE m.ts_ms BETWEEN $1 AND $2
      GROUP BY pms.club_id, pms.player_id, p.name
   ),
   scorers AS (
@@ -56,10 +41,7 @@ const SQL_LEADERS = `
 
 async function rebuildUpclLeaders() {
   await q('TRUNCATE TABLE public.upcl_leaders');
-  await q(
-    'INSERT INTO public.upcl_leaders (type, club_id, name, count) ' + SQL_LEADERS,
-    [LEAGUE_START_MS, LEAGUE_END_MS]
-  );
+  await q('INSERT INTO public.upcl_leaders (type, club_id, name, count) ' + SQL_LEADERS);
 }
 
 module.exports = { rebuildUpclLeaders };

--- a/server.js
+++ b/server.js
@@ -220,10 +220,6 @@ const LEAGUE_START_MS = parseDateMs(
   process.env.LEAGUE_START_MS,
   Date.parse('2025-08-27T23:59:00-07:00')
 );
-const LEAGUE_END_MS = parseDateMs(
-  process.env.LEAGUE_END_MS,
-  Date.parse('2025-09-03T23:59:00-07:00')
-);
 
 function resolveClubIds() {
   let ids = clubsForLeague(DEFAULT_LEAGUE_ID);
@@ -809,7 +805,6 @@ app.get('/api/league/leaders', async (_req, res) => {
       JOIN public.matches m ON m.match_id = pms.match_id
       JOIN public.players p ON p.player_id = pms.player_id AND p.club_id = pms.club_id
      WHERE pms.club_id = ANY($1::bigint[])
-       AND m.ts_ms BETWEEN $2 AND $3
      GROUP BY pms.club_id, p.name
      ORDER BY count DESC, p.name
      LIMIT 10`;
@@ -819,14 +814,13 @@ app.get('/api/league/leaders', async (_req, res) => {
       JOIN public.matches m ON m.match_id = pms.match_id
       JOIN public.players p ON p.player_id = pms.player_id AND p.club_id = pms.club_id
      WHERE pms.club_id = ANY($1::bigint[])
-       AND m.ts_ms BETWEEN $2 AND $3
      GROUP BY pms.club_id, p.name
      ORDER BY count DESC, p.name
      LIMIT 10`;
   try {
     const [scorers, assisters] = await Promise.all([
-      q(scorerSql, [clubIds, LEAGUE_START_MS, LEAGUE_END_MS]),
-      q(assisterSql, [clubIds, LEAGUE_START_MS, LEAGUE_END_MS])
+      q(scorerSql, [clubIds]),
+      q(assisterSql, [clubIds])
     ]);
     res.json({
       scorers: scorers.rows,

--- a/test/leagueLeadersApi.test.js
+++ b/test/leagueLeadersApi.test.js
@@ -7,9 +7,7 @@ process.env.LEAGUE_CLUBS_PATH = path.join(__dirname, 'fixtures', 'leagueClubs.js
 process.env.DEFAULT_LEAGUE_ID = 'test';
 // Override league range to ensure server reads from environment variables
 const LEAGUE_START_MS = 123456;
-const LEAGUE_END_MS = 789012;
 process.env.LEAGUE_START_MS = String(LEAGUE_START_MS);
-process.env.LEAGUE_END_MS = String(LEAGUE_END_MS);
 
 const { pool } = require('../db');
 
@@ -31,12 +29,12 @@ test('serves league leaders', async () => {
   const stub = mock.method(pool, 'query', async (sql, params) => {
     if (/SUM\(pms\.goals\)/i.test(sql)) {
       assert.match(sql, /ANY\(\$1::bigint\[\]\)/i);
-      assert.deepStrictEqual(params, [[1], LEAGUE_START_MS, LEAGUE_END_MS]);
+      assert.deepStrictEqual(params, [[1]]);
       return { rows: scorerRows };
     }
     if (/SUM\(pms\.assists\)/i.test(sql)) {
       assert.match(sql, /ANY\(\$1::bigint\[\]\)/i);
-      assert.deepStrictEqual(params, [[1], LEAGUE_START_MS, LEAGUE_END_MS]);
+      assert.deepStrictEqual(params, [[1]]);
       return { rows: assisterRows };
     }
     return { rows: [] };


### PR DESCRIPTION
## Summary
- stop filtering `/api/league/leaders` results by the season date range so stored stats always appear
- align the UPCL leaders rebuild script and documentation with the new behavior
- update the league leaders API test to reflect the simplified SQL parameters

## Testing
- npm test -- test/leagueLeadersApi.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc4a499ff8832ebcbc8a8d43be4e2a