### PR TITLE
Restrict standings to official league clubs

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -3132,6 +3132,8 @@ function renderStandings(rows, matches, fallbackRows = []){
 function computeStandings(rows, matches, fallbackRows = []){
   const allowedClubIds = new Set();
   const nameFallbacks = new Map();
+  const hasPrimaryStandings = Array.isArray(rows) && rows.length > 0;
+
   (rows || []).forEach(r => {
     const rawId = r?.club_id ?? r?.clubId ?? r?.id;
     if (!rawId) return;
@@ -3145,9 +3147,14 @@ function computeStandings(rows, matches, fallbackRows = []){
     const rawId = r?.clubId ?? r?.club_id ?? r?.id;
     if (!rawId) return;
     const id = String(rawId);
-    allowedClubIds.add(id);
     const label = r?.name || r?.club_name || r?.club || r?.team;
-    if (label && !nameFallbacks.has(id)) nameFallbacks.set(id, label);
+    if (!hasPrimaryStandings && !allowedClubIds.has(id)){
+      allowedClubIds.add(id);
+    }
+    if (label){
+      const canUseLabel = !hasPrimaryStandings || allowedClubIds.has(id);
+      if (canUseLabel && !nameFallbacks.has(id)) nameFallbacks.set(id, label);
+    }
   });
 
   if (!allowedClubIds.size){
@@ -3159,6 +3166,10 @@ function computeStandings(rows, matches, fallbackRows = []){
   }
 
   const standingsMap = new Map();
+  const clubIsAllowed = clubId => {
+    if (!allowedClubIds.size) return !hasPrimaryStandings;
+    return allowedClubIds.has(String(clubId ?? ''));
+  };
   const ensureEntry = (clubId, clubData = {}) => {
     const id = String(clubId);
     if (!standingsMap.has(id)){
@@ -3219,9 +3230,7 @@ function computeStandings(rows, matches, fallbackRows = []){
     }
   });
 
-  let computed = Array.from(standingsMap.values()).filter(entry => {
-    return !allowedClubIds.size || allowedClubIds.has(String(entry?.clubId ?? ''));
-  });
+  let computed = Array.from(standingsMap.values()).filter(entry => clubIsAllowed(entry?.clubId));
   if (!computed.length){
     computed = (rows || []).map(r => {
       const id = r?.club_id ?? r?.clubId ?? r?.id;
@@ -3242,9 +3251,7 @@ function computeStandings(rows, matches, fallbackRows = []){
         points: Number(r?.points ?? 0)
       };
     }).filter(Boolean);
-    computed = computed.filter(entry => {
-      return !allowedClubIds.size || allowedClubIds.has(String(entry?.clubId ?? ''));
-    });
+    computed = computed.filter(entry => clubIsAllowed(entry?.clubId));
   }
 
   if (!computed.length && fallbackRows && fallbackRows.length){
@@ -3267,11 +3274,10 @@ function computeStandings(rows, matches, fallbackRows = []){
         points: Number(r?.points ?? 0)
       };
     }).filter(Boolean);
+    computed = computed.filter(entry => clubIsAllowed(entry?.clubId));
   }
 
-  computed = computed.filter(entry => {
-    return !allowedClubIds.size || allowedClubIds.has(String(entry?.clubId ?? ''));
-  });
+  computed = computed.filter(entry => clubIsAllowed(entry?.clubId));
 
   computed.forEach(entry => {
     if (!entry.name){


### PR DESCRIPTION
## Summary
- keep the allowed club list sourced from the league standings response unless it is empty
- let player fallback rows provide names for known clubs without expanding the official club set
- filter all computed standings outputs so clubs outside the configured league are excluded

## Testing
- npm test
- node <<'NODE'
const fs = require('fs');
const vm = require('vm');
const html = fs.readFileSync('public/teams.html','utf8');
const match = html.match(/function computeStandings[\s\S]*?return computed;\n}\n/);
const teams = [{ id: '1', name: 'Alpha' }, { id: '2', name: 'Beta' }];
function byId(id){
  return teams.find(t => String(t.id) === String(id));
}
const context = { teams, byId, console };
vm.createContext(context);
vm.runInContext(match[0], context);
const { computeStandings } = context;
const rows = [
  { club_id: '1', club_name: 'Alpha FC' },
  { club_id: '2', club_name: 'Beta FC' }
];
const matches = [
  { clubs: { '1': { goals: 1, details: { name: 'Alpha FC' } }, '3': { goals: 0, details: { name: 'Gamma FC' } } } },
  { clubs: { '2': { goals: 2, details: { name: 'Beta FC' } }, '3': { goals: 2, details: { name: 'Gamma FC' } } } }
];
const fallbackRows = [
  { clubId: '1', name: 'Alpha Alt' },
  { clubId: '3', name: 'Gamma Alt' }
];
const standings = computeStandings(rows, matches, fallbackRows);
console.log(JSON.stringify(standings, null, 2));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68dc57aba87c832e82aa05c50a895763