### PR TITLE
Fetch and store club divisions during match ingestion

### DIFF
--- a/migrations/2026-03-05_add_match_divisions.sql
+++ b/migrations/2026-03-05_add_match_divisions.sql
@@ -1,0 +1,4 @@
+-- Add division columns to matches for home and away clubs
+ALTER TABLE public.matches
+  ADD COLUMN IF NOT EXISTS home_division INT,
+  ADD COLUMN IF NOT EXISTS away_division INT;


### PR DESCRIPTION
## Summary
- add home and away division columns to stored matches
- fetch leaderboard divisions for each club during match ingestion and persist them
- cache leaderboard division lookups and extend saveEaMatch tests for the new behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc6428eebc832ebe55e5e96f9e814a