### PR TITLE
Filter auto news standings to league clubs

### DIFF
--- a/test/newsFeed.test.js
+++ b/test/newsFeed.test.js
@@ -1,0 +1,77 @@
+const { test, mock } = require('node:test');
+const assert = require('assert');
+const path = require('path');
+
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+process.env.LEAGUE_CLUBS_PATH = path.join(__dirname, 'fixtures', 'leagueClubs.json');
+process.env.DEFAULT_LEAGUE_ID = 'test';
+
+const { pool } = require('../db');
+
+async function withServer(fn) {
+  const app = require('../server');
+  const server = app.listen(0);
+  try {
+    const port = server.address().port;
+    await fn(port);
+  } finally {
+    server.close();
+  }
+}
+
+test('auto standings card excludes clubs outside the league', async () => {
+  const stub = mock.method(pool, 'query', async (sql, params) => {
+    if (/FROM public\.news/i.test(sql)) {
+      return { rows: [] };
+    }
+    if (/FROM public\.upcl_standings/i.test(sql)) {
+      assert.match(sql, /club_id::bigint = ANY\(\$1::bigint\[\]\)/i);
+      assert.deepStrictEqual(params, [[1]]);
+      return {
+        rows: [
+          {
+            club_id: 1,
+            pts: 22,
+            w: 7,
+            d: 1,
+            l: 2,
+            gf: 25,
+            ga: 15,
+            gd: 10,
+            updated_at: new Date('2024-01-01T00:00:00Z')
+          },
+          {
+            club_id: 999,
+            pts: 30,
+            w: 10,
+            d: 0,
+            l: 0,
+            gf: 40,
+            ga: 0,
+            gd: 40,
+            updated_at: new Date('2024-01-02T00:00:00Z')
+          }
+        ]
+      };
+    }
+    if (/FROM public\.upcl_leaders/i.test(sql)) {
+      return { rows: [] };
+    }
+    if (/FROM public\.matches m/i.test(sql)) {
+      return { rows: [] };
+    }
+    return { rows: [] };
+  });
+
+  await withServer(async port => {
+    const res = await fetch(`http://localhost:${port}/api/news`);
+    assert.strictEqual(res.status, 200);
+    const body = await res.json();
+    const standingsCard = body.items.find(item => item.id === 'auto-standings');
+    assert(standingsCard, 'expected auto standings card');
+    assert.deepStrictEqual(standingsCard.stats.map(s => s.clubId), ['1']);
+    assert.strictEqual(standingsCard.stats.length, 1);
+  });
+
+  stub.mock.restore();
+});


### PR DESCRIPTION
## Summary
- filter the standings query by the resolved league club ids
- call resolveClubIds when building auto news and drop standings for clubs outside the league
- add a news feed test that ensures out-of-league standings rows are excluded from the auto card

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc7b0b5654832e84f6728931832654