### PR TITLE
Fix club_id casting in hidden gem candidate query

### DIFF
--- a/server.js
+++ b/server.js
@@ -244,9 +244,9 @@ const SQL_HIDDEN_GEM_CANDIDATES = `
     FROM public.player_match_stats pms
     JOIN public.players p
       ON p.player_id = pms.player_id
-     AND p.club_id = pms.club_id
+     AND p.club_id::text = pms.club_id::text
     LEFT JOIN public.clubs c
-      ON c.club_id = p.club_id
+      ON c.club_id::text = p.club_id::text
    WHERE COALESCE(p.overall_rating, 0) <= 75
    GROUP BY p.player_id, p.name, p.position, p.club_id, p.overall_rating, c.club_name
   HAVING COUNT(*) >= 5


### PR DESCRIPTION
## Summary
- ensure the hidden gem candidate query casts club_id joins to a common text type to prevent bigint/text mismatches

## Testing
- npm test -- test/newsFeed.test.js *(fails: Cannot find module 'multer')*


------
https://chatgpt.com/codex/tasks/task_e_68df06a78eac832e9dcd7dcd57a8546e