### PR TITLE
Normalize bigint database parameters

### DIFF
--- a/services/pgwrap.js
+++ b/services/pgwrap.js
@@ -1,5 +1,46 @@
 const { pool } = require('../db');
 
+function toBigIntParam(value) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+  if (typeof value === 'boolean') {
+    return value ? 1 : 0;
+  }
+  const str = String(value).trim();
+  if (!str) {
+    return null;
+  }
+  if (!/^[-+]?\d+$/.test(str)) {
+    throw new TypeError(`Invalid bigint value: ${value}`);
+  }
+  const num = Number(str);
+  if (!Number.isFinite(num)) {
+    // Fallback to BigInt to avoid NaN for very large ids
+    return Number(BigInt(str));
+  }
+  return Math.trunc(num);
+}
+
+function toBigIntArray(values) {
+  if (!values) return [];
+  const arr = Array.isArray(values) ? values : [values];
+  const result = [];
+  for (const val of arr) {
+    const converted = toBigIntParam(val);
+    if (converted !== null) {
+      result.push(converted);
+    }
+  }
+  return result;
+}
+
 async function q(text, params) {
   try { return await pool.query(text, params); }
   catch (err) {
@@ -9,4 +50,4 @@ async function q(text, params) {
     throw err;
   }
 }
-module.exports = { q };
+module.exports = { q, toBigIntParam, toBigIntArray };

--- a/services/playerAttributes.js
+++ b/services/playerAttributes.js
@@ -1,21 +1,53 @@
 const { pool } = require('../db');
 const { parseVpro } = require('./playerCards');
+const { toBigIntParam } = require('./pgwrap');
 
 async function getPlayerAttributes(playerId, clubId) {
+  let useNumeric = true;
+  let clubIdParam;
+  let playerIdParam;
+  try {
+    clubIdParam = toBigIntParam(clubId);
+    playerIdParam = toBigIntParam(playerId);
+  } catch (err) {
+    if (err instanceof TypeError) {
+      useNumeric = false;
+    } else {
+      throw err;
+    }
+  }
+  if (clubIdParam === null || playerIdParam === null) {
+    useNumeric = false;
+  }
+
+  const clubKey = String(useNumeric ? clubIdParam : clubId ?? '');
+  const playerKey = String(useNumeric ? playerIdParam : playerId ?? '');
+  const matchParam = useNumeric ? clubIdParam : String(clubId ?? '');
+  const matchWhere = useNumeric
+    ? 'WHERE mp.club_id::bigint = $3::bigint'
+    : 'WHERE mp.club_id::text = $3::text';
+
   const m = await pool.query(
     `SELECT m.raw->'players'->$1->$2->>'vproattr' AS vproattr
        FROM public.matches m
        JOIN public.match_participants mp ON mp.match_id = m.match_id
-       WHERE mp.club_id = $1
+       ${matchWhere}
        ORDER BY m.ts_ms DESC
        LIMIT 1`,
-    [clubId, playerId]
+    [clubKey, playerKey, matchParam]
   );
   if (m.rows[0]?.vproattr) return parseVpro(m.rows[0].vproattr);
 
+  const playerWhere = useNumeric
+    ? 'WHERE player_id::bigint = $1::bigint AND club_id::bigint = $2::bigint'
+    : 'WHERE player_id::text = $1::text AND club_id::text = $2::text';
+  const playerParams = useNumeric
+    ? [playerIdParam, clubIdParam]
+    : [String(playerId ?? ''), String(clubId ?? '')];
+
   const p = await pool.query(
-    `SELECT vproattr FROM public.players WHERE player_id = $1 AND club_id = $2`,
-    [playerId, clubId]
+    `SELECT vproattr FROM public.players ${playerWhere}`,
+    playerParams
   );
   if (p.rows[0]?.vproattr) return parseVpro(p.rows[0].vproattr);
 


### PR DESCRIPTION
## Summary
- add shared helpers to coerce bigint identifiers before querying Postgres
- sanitize match ingestion, pending approvals, and club/player APIs to pass numeric IDs and cast bigint filters
- update player attribute lookups and match fetch script to handle numeric inputs safely

## Testing
- npm test *(fails: missing optional dependency `multer` in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df0e2e9b04832eb57623309bafb5ef