### PR TITLE
Fix player card queries for bigint ids

### DIFF
--- a/scripts/rebuildUpclLeaders.js
+++ b/scripts/rebuildUpclLeaders.js
@@ -2,15 +2,15 @@ const { q } = require('../services/pgwrap');
 
 const SQL_LEADERS = `
   WITH league_players AS (
-    SELECT pms.club_id,
+    SELECT pms.club_id::bigint AS club_id,
            p.name,
            SUM(pms.goals)   AS goals,
            SUM(pms.assists) AS assists
       FROM public.player_match_stats pms
-      JOIN public.matches m ON m.match_id = pms.match_id
-      JOIN public.players p ON p.player_id = pms.player_id
-      JOIN public.upcl_standings s ON s.club_id = pms.club_id
-     GROUP BY pms.club_id, pms.player_id, p.name
+      JOIN public.matches m ON m.match_id::bigint = pms.match_id::bigint
+      JOIN public.players p ON p.player_id::bigint = pms.player_id::bigint
+      JOIN public.upcl_standings s ON s.club_id::bigint = pms.club_id::bigint
+      GROUP BY pms.club_id::bigint, pms.player_id::bigint, p.name
   ),
   scorers AS (
     SELECT 'scorer'::text AS type,

--- a/scripts/rebuildUpclStandings.js
+++ b/scripts/rebuildUpclStandings.js
@@ -2,15 +2,15 @@ const { q } = require('../services/pgwrap');
 
 const SQL_LEAGUE_STANDINGS = `
   WITH matches AS (
-    SELECT home.club_id AS home,
-           away.club_id AS away,
+    SELECT home.club_id::bigint AS home,
+           away.club_id::bigint AS away,
            home.goals AS home_goals,
            away.goals AS away_goals
       FROM public.matches m
       JOIN public.match_participants home
-        ON home.match_id = m.match_id AND home.is_home = true
+        ON home.match_id::bigint = m.match_id::bigint AND home.is_home = true
       JOIN public.match_participants away
-        ON away.match_id = m.match_id AND away.is_home = false
+        ON away.match_id::bigint = m.match_id::bigint AND away.is_home = false
   ), sides AS (
     SELECT home AS club_id, away AS opp_id, home_goals AS gf, away_goals AS ga
       FROM matches

--- a/services/newsGenerator.js
+++ b/services/newsGenerator.js
@@ -50,9 +50,9 @@ const SQL_RECENT_MATCHES = `
          away.goals    AS away_goals
     FROM public.matches m
     JOIN public.match_participants home
-      ON home.match_id = m.match_id AND home.is_home = true
+      ON home.match_id::bigint = m.match_id::bigint AND home.is_home = true
     JOIN public.match_participants away
-      ON away.match_id = m.match_id AND away.is_home = false
+      ON away.match_id::bigint = m.match_id::bigint AND away.is_home = false
    WHERE m.ts_ms >= $1
    ORDER BY m.ts_ms DESC
    LIMIT 400
@@ -72,8 +72,8 @@ const SQL_RECENT_PLAYER_STATS = `
          p.name,
          p.position
     FROM public.player_match_stats pms
-    JOIN public.matches m ON m.match_id = pms.match_id
-    JOIN public.players p ON p.player_id = pms.player_id AND p.club_id = pms.club_id
+    JOIN public.matches m ON m.match_id::bigint = pms.match_id::bigint
+    JOIN public.players p ON p.player_id::bigint = pms.player_id::bigint AND p.club_id::bigint = pms.club_id::bigint
    WHERE m.ts_ms >= $1
 `;
 

--- a/services/playerAttributes.js
+++ b/services/playerAttributes.js
@@ -30,7 +30,7 @@ async function getPlayerAttributes(playerId, clubId) {
   const m = await pool.query(
     `SELECT m.raw->'players'->$1->$2->>'vproattr' AS vproattr
        FROM public.matches m
-       JOIN public.match_participants mp ON mp.match_id = m.match_id
+       JOIN public.match_participants mp ON mp.match_id::bigint = m.match_id::bigint
        ${matchWhere}
        ORDER BY m.ts_ms DESC
        LIMIT 1`,

--- a/services/statsIntegrity.js
+++ b/services/statsIntegrity.js
@@ -6,7 +6,7 @@ const SQL = `
          mp.goals::int AS team_goals
     FROM public.match_participants mp
     LEFT JOIN public.player_match_stats pms
-           ON pms.match_id = mp.match_id AND pms.club_id = mp.club_id
+           ON pms.match_id::bigint = mp.match_id::bigint AND pms.club_id::bigint = mp.club_id::bigint
    GROUP BY mp.match_id, mp.club_id, mp.goals
   HAVING COALESCE(SUM(pms.goals), 0)::int <> mp.goals::int
 `;


### PR DESCRIPTION
## Summary
- cast match participant identifiers to bigint when joining against player stats, matches, and clubs
- align league helper scripts and news queries with bigint comparisons to avoid bigint/text operator errors

## Testing
- npm test -- test/playerCardsApi.test.js *(fails: missing module 'multer')*

------
https://chatgpt.com/codex/tasks/task_e_68df1623de84832ea34246e5c5f50c56