### PR TITLE
Add player card background photo support

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -682,22 +682,30 @@ h2{margin:0 0 12px;font-size:28px;letter-spacing:0.08em;text-transform:uppercase
   position:absolute;
   inset:0;
   border-radius:inherit;
-  background:linear-gradient(180deg,rgba(255,255,255,0.08),rgba(15,23,42,0.05));
-  mix-blend-mode:screen;
-  opacity:0.4;
+  background-image:var(--player-card-photo);
+  background-size:cover;
+  background-position:center;
+  background-repeat:no-repeat;
+  opacity:0;
+  transition:opacity .4s ease;
   pointer-events:none;
-  transition:opacity .3s ease;
+  z-index:0;
 }
 .player-card::after{
   content:"";
   position:absolute;
   inset:0;
   border-radius:inherit;
+  background:linear-gradient(180deg,rgba(255,255,255,0.08),rgba(15,23,42,0.05));
+  mix-blend-mode:screen;
   border:1px solid rgba(255,255,255,0.06);
   pointer-events:none;
-  transition:box-shadow .3s ease, border-color .3s ease, opacity .3s ease;
+  transition:opacity .3s ease, box-shadow .3s ease, border-color .3s ease;
   opacity:0.7;
+  z-index:1;
 }
+.player-card > *{position:relative;z-index:2;}
+.player-card[data-has-photo="true"]::before{opacity:1;}
 .player-card:hover,
 .player-card:focus-visible{
   outline:none;
@@ -705,8 +713,6 @@ h2{margin:0 0 12px;font-size:28px;letter-spacing:0.08em;text-transform:uppercase
   box-shadow:0 26px 60px rgba(2,6,23,0.65),0 0 40px var(--card-glow-shadow, rgba(56,189,248,0.18));
   border-color:var(--card-glow);
 }
-.player-card:hover::before,
-.player-card:focus-visible::before{opacity:0.65;}
 .player-card:hover::after,
 .player-card:focus-visible::after{
   border-color:var(--card-glow);
@@ -3157,6 +3163,8 @@ function applyPlayerImage(card, imageUrl, playerName){
     if(!normalizedUrl){
       avatar.classList.remove('has-image');
       avatar.dataset.hasPhoto = 'false';
+      card.style.removeProperty('--player-card-photo');
+      card.dataset.hasPhoto = 'false';
     }
     return;
   }
@@ -3167,11 +3175,15 @@ function applyPlayerImage(card, imageUrl, playerName){
     img.alt = playerName ? `${playerName} portrait` : 'Player portrait';
     avatar.classList.add('has-image');
     avatar.dataset.hasPhoto = 'true';
+    card.style.setProperty('--player-card-photo', `url("${finalUrl}")`);
+    card.dataset.hasPhoto = 'true';
   }else{
     img.removeAttribute('src');
     img.alt = '';
     avatar.classList.remove('has-image');
     avatar.dataset.hasPhoto = 'false';
+    card.style.removeProperty('--player-card-photo');
+    card.dataset.hasPhoto = 'false';
   }
 }
 


### PR DESCRIPTION
## Summary
- render player card backgrounds through a pseudo-element that fades in when a photo is present
- keep gradient and border overlays above the photo while ensuring card content sits on top
- sync player image handling to update the new CSS custom property and dataset state when photos are set or cleared

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df2fe46e14832eae9dbf0beba56574