### PR TITLE
Redesign Tables and Playoffs UI for professional esports look

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -241,253 +241,267 @@
 
     .league-grid {
       display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 16px;
+      grid-template-columns: 1fr;
+      gap: 18px;
     }
 
     .standings-card {
       overflow: hidden;
+      border-radius: 6px;
+      background: #10141b;
+      border-color: rgba(148, 163, 184, 0.2);
+      box-shadow: 0 14px 34px rgba(0, 0, 0, 0.26);
+      backdrop-filter: none;
     }
 
     .section-heading {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 12px;
-      padding: 18px 18px 8px;
+      gap: 16px;
+      padding: 18px 20px;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+      background: #151a22;
     }
 
     .section-heading h2,
     .round h3 {
       margin: 0;
-      font-size: 1rem;
-      letter-spacing: 0.16em;
+      font-size: 0.96rem;
+      letter-spacing: 0.12em;
       text-transform: uppercase;
     }
 
     .conference-chip,
     .round-chip {
-      border: 1px solid rgba(56, 189, 248, 0.36);
-      border-radius: 999px;
-      padding: 7px 10px;
-      color: var(--accent-2);
-      font-size: 0.72rem;
-      font-weight: 900;
-      letter-spacing: 0.12em;
+      border: 1px solid rgba(52, 211, 153, 0.36);
+      border-radius: 3px;
+      padding: 6px 9px;
+      color: #9fe7bf;
+      font-size: 0.68rem;
+      font-weight: 850;
+      letter-spacing: 0.1em;
       text-transform: uppercase;
-      background: rgba(56, 189, 248, 0.08);
+      background: rgba(52, 211, 153, 0.08);
     }
 
     .table-wrap {
       overflow-x: auto;
-      padding: 0 14px 16px;
+      padding: 0;
     }
 
     table.standings {
       width: 100%;
-      min-width: 760px;
+      min-width: 860px;
       border-collapse: collapse;
       font-variant-numeric: tabular-nums;
+      background: #0d1117;
     }
 
     .standings th,
     .standings td {
-      padding: 12px 10px;
+      padding: 14px 14px;
       text-align: center;
-      border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+      border-bottom: 1px solid rgba(148, 163, 184, 0.12);
     }
 
     .standings th {
-      color: var(--muted);
-      font-size: 0.72rem;
-      letter-spacing: 0.12em;
+      color: #9aa6b6;
+      font-size: 0.7rem;
+      font-weight: 850;
+      letter-spacing: 0.11em;
       text-transform: uppercase;
+      background: #0b0f14;
+    }
+
+    .standings tbody tr {
+      background: #10151c;
+      transition: background 140ms ease;
+    }
+
+    .standings tbody tr:nth-child(even) {
+      background: #0d1218;
+    }
+
+    .standings tbody tr:hover {
+      background: #17201f;
+    }
+
+    .standings tbody tr:nth-child(-n+2) {
+      background: rgba(52, 211, 153, 0.06);
+    }
+
+    .standings tbody tr.cutoff td {
+      border-bottom: 2px solid rgba(52, 211, 153, 0.44);
+    }
+
+    .standings td.seed-cell {
+      color: #cbd5e1;
+      font-weight: 900;
+      width: 64px;
     }
 
     .standings td.team-cell {
-      min-width: 180px;
+      min-width: 260px;
       text-align: left;
       font-weight: 900;
     }
 
-    .standings tbody tr:nth-child(-n+2) {
-      background: linear-gradient(90deg, rgba(52, 211, 153, 0.13), transparent 58%);
+    .club-cell {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      min-width: 0;
     }
 
-    .standings tbody tr.cutoff td {
-      border-bottom: 2px dashed rgba(52, 211, 153, 0.62);
+    .club-logo,
+    .team-logo {
+      flex: 0 0 auto;
+      object-fit: contain;
+      background: #161c24;
+    }
+
+    .club-logo {
+      width: 34px;
+      height: 34px;
+      padding: 3px;
+      border: 1px solid rgba(148, 163, 184, 0.18);
+    }
+
+    .club-name-wrap {
+      display: grid;
+      gap: 3px;
+      min-width: 0;
+    }
+
+    .club-name {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: #ffffff;
+    }
+
+    .club-note {
+      color: #8e9aaa;
+      font-size: 0.68rem;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .record-cell {
+      color: #eef4fa;
+      font-weight: 900;
+      letter-spacing: 0.02em;
+    }
+
+    .points-cell {
+      color: #ffffff;
+      font-weight: 950;
     }
 
     .badge {
       display: inline-flex;
       align-items: center;
-      gap: 6px;
-      margin-left: 8px;
-      border: 1px solid rgba(52, 211, 153, 0.75);
-      border-radius: 999px;
-      padding: 4px 8px;
-      color: #bbf7d0;
-      font-size: 0.68rem;
-      font-weight: 950;
+      margin-top: 2px;
+      border-left: 3px solid var(--accent);
+      padding-left: 7px;
+      color: #9fe7bf;
+      font-size: 0.66rem;
+      font-weight: 900;
       letter-spacing: 0.08em;
       text-transform: uppercase;
-      background: rgba(52, 211, 153, 0.14);
-      box-shadow: 0 0 18px var(--glow);
     }
 
     .form {
       display: inline-flex;
-      gap: 4px;
+      gap: 5px;
       justify-content: center;
     }
 
     .form span {
       display: grid;
       place-items: center;
-      width: 22px;
-      height: 22px;
-      border-radius: 7px;
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
       color: #03121a;
-      font-size: 0.7rem;
+      font-size: 0;
       font-weight: 950;
+      border: 1px solid rgba(255, 255, 255, 0.16);
     }
 
-    .form .W { background: var(--accent); }
-    .form .D { background: var(--draw); }
-    .form .L { background: var(--danger); color: #fff1f2; }
+    .form span::after {
+      content: attr(aria-label);
+      font-size: 0.58rem;
+      line-height: 1;
+    }
+
+    .form .W { background: #34d399; }
+    .form .D { background: #d6a827; }
+    .form .L { background: #b54a58; color: #fff1f2; }
 
     .playoff-panel {
       position: relative;
       width: calc(100vw - 32px);
       margin-left: calc(50% - 50vw + 16px);
-      min-height: 700px;
-      padding: clamp(22px, 4vw, 46px);
+      min-height: 640px;
+      padding: clamp(22px, 3vw, 38px);
       overflow: hidden;
-      border-color: rgba(0, 255, 102, 0.24);
-      border-radius: 18px;
-      background:
-        radial-gradient(circle at 50% 10%, rgba(0, 255, 102, 0.14), transparent 28rem),
-        radial-gradient(circle at 16% 42%, rgba(0, 194, 255, 0.15), transparent 24rem),
-        radial-gradient(circle at 84% 48%, rgba(255, 61, 242, 0.1), transparent 24rem),
-        linear-gradient(135deg, #010207 0%, #03111c 48%, #020409 100%);
-      box-shadow:
-        inset 0 0 90px rgba(0, 194, 255, 0.08),
-        0 28px 100px rgba(0, 0, 0, 0.48),
-        0 0 44px rgba(0, 255, 102, 0.08);
+      border-color: rgba(148, 163, 184, 0.2);
+      border-radius: 6px;
+      background: #0b0f14;
+      box-shadow: 0 18px 44px rgba(0, 0, 0, 0.34);
+      backdrop-filter: none;
       isolation: isolate;
     }
 
     .playoff-panel::before,
-    .playoff-panel::after {
-      content: '';
-      position: absolute;
-      inset: 0;
-      pointer-events: none;
-      z-index: 0;
-    }
-
-    .playoff-panel::before {
-      background:
-        linear-gradient(rgba(0, 194, 255, 0.07) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(0, 255, 102, 0.055) 1px, transparent 1px);
-      background-size: 42px 42px;
-      mask-image: radial-gradient(ellipse at center, black 0%, rgba(0, 0, 0, 0.72) 54%, transparent 82%);
-      transform: perspective(720px) rotateX(58deg) translateY(-12%);
-      transform-origin: 50% 0;
-      animation: gridDrift 18s linear infinite;
-    }
-
-    .playoff-panel::after {
-      background: linear-gradient(100deg, transparent 0%, rgba(0, 255, 102, 0) 42%, rgba(0, 255, 102, 0.16) 49%, rgba(0, 194, 255, 0.2) 51%, rgba(0, 255, 102, 0) 58%, transparent 100%);
-      width: 38%;
-      filter: blur(10px);
-      mix-blend-mode: screen;
-      animation: scanSweep 9s ease-in-out infinite;
-    }
-
+    .playoff-panel::after,
     .particle-field {
-      position: absolute;
-      inset: 0;
-      overflow: hidden;
-      pointer-events: none;
-      z-index: 1;
+      display: none;
     }
-
-    .particle-field span {
-      position: absolute;
-      width: var(--size, 4px);
-      height: var(--size, 4px);
-      left: var(--x, 50%);
-      top: var(--y, 50%);
-      border-radius: 999px;
-      background: var(--color, #00ff66);
-      opacity: 0.65;
-      box-shadow: 0 0 16px var(--color, #00ff66), 0 0 28px rgba(0, 194, 255, 0.24);
-      animation: particleFloat var(--duration, 14s) ease-in-out infinite alternate;
-      animation-delay: var(--delay, 0s);
-    }
-
-    .particle-field span:nth-child(1) { --x: 7%; --y: 18%; --size: 3px; --duration: 16s; --delay: -2s; }
-    .particle-field span:nth-child(2) { --x: 14%; --y: 76%; --size: 5px; --duration: 19s; --delay: -8s; --color: #00c2ff; }
-    .particle-field span:nth-child(3) { --x: 23%; --y: 33%; --size: 4px; --duration: 15s; --delay: -4s; }
-    .particle-field span:nth-child(4) { --x: 30%; --y: 67%; --size: 2px; --duration: 20s; --delay: -10s; --color: #ff3df2; }
-    .particle-field span:nth-child(5) { --x: 42%; --y: 21%; --size: 4px; --duration: 18s; --delay: -7s; --color: #00c2ff; }
-    .particle-field span:nth-child(6) { --x: 48%; --y: 84%; --size: 3px; --duration: 22s; --delay: -13s; }
-    .particle-field span:nth-child(7) { --x: 57%; --y: 15%; --size: 5px; --duration: 17s; --delay: -5s; }
-    .particle-field span:nth-child(8) { --x: 63%; --y: 73%; --size: 3px; --duration: 21s; --delay: -11s; --color: #00c2ff; }
-    .particle-field span:nth-child(9) { --x: 74%; --y: 35%; --size: 4px; --duration: 16s; --delay: -1s; }
-    .particle-field span:nth-child(10) { --x: 82%; --y: 63%; --size: 2px; --duration: 23s; --delay: -9s; --color: #ff3df2; }
-    .particle-field span:nth-child(11) { --x: 90%; --y: 22%; --size: 5px; --duration: 18s; --delay: -12s; --color: #00c2ff; }
-    .particle-field span:nth-child(12) { --x: 94%; --y: 82%; --size: 3px; --duration: 20s; --delay: -6s; }
 
     .playoff-stage-header {
       position: relative;
       z-index: 2;
       display: grid;
-      justify-items: center;
       gap: 8px;
-      margin-bottom: clamp(24px, 4vw, 44px);
-      text-align: center;
+      margin-bottom: clamp(22px, 3vw, 34px);
+      padding-bottom: 18px;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+      text-align: left;
     }
 
     .playoff-kicker {
-      display: inline-flex;
-      align-items: center;
-      gap: 9px;
       margin: 0;
-      color: #00ff66;
-      font-size: 0.74rem;
-      font-weight: 950;
-      letter-spacing: 0.22em;
+      color: #8adfaf;
+      font-size: 0.72rem;
+      font-weight: 900;
+      letter-spacing: 0.18em;
       text-transform: uppercase;
-      text-shadow: 0 0 18px rgba(0, 255, 102, 0.42);
+      text-shadow: none;
     }
 
     .playoff-kicker::before,
     .playoff-kicker::after {
-      content: '';
-      width: 46px;
-      height: 1px;
-      background: linear-gradient(90deg, transparent, #00ff66);
-      box-shadow: 0 0 12px rgba(0, 255, 102, 0.8);
+      display: none;
     }
-
-    .playoff-kicker::after { transform: scaleX(-1); }
 
     .playoff-stage-header h2 {
       margin: 0;
-      font-size: clamp(2.2rem, 5.4vw, 5.8rem);
-      line-height: 0.86;
-      letter-spacing: -0.08em;
+      font-size: clamp(1.8rem, 3.6vw, 3.5rem);
+      line-height: 1;
+      letter-spacing: -0.045em;
       text-transform: uppercase;
-      text-shadow: 0 0 36px rgba(0, 194, 255, 0.32);
+      text-shadow: none;
     }
 
     .playoff-stage-header p {
       max-width: 760px;
       margin: 0;
-      color: #a8b4c6;
-      font-size: clamp(0.92rem, 1.6vw, 1.05rem);
+      color: #9aa6b6;
+      font-size: clamp(0.9rem, 1.4vw, 1rem);
       line-height: 1.6;
     }
 
@@ -501,8 +515,8 @@
 
     .bracket-desktop {
       display: grid;
-      grid-template-columns: minmax(210px, 1fr) minmax(210px, 0.9fr) minmax(360px, 1.7fr) minmax(210px, 0.9fr) minmax(210px, 1fr);
-      gap: clamp(12px, 1.5vw, 26px);
+      grid-template-columns: minmax(220px, 1fr) minmax(220px, 0.9fr) minmax(360px, 1.45fr) minmax(220px, 0.9fr) minmax(220px, 1fr);
+      gap: clamp(12px, 1.5vw, 24px);
       align-items: center;
       min-width: 1180px;
     }
@@ -512,23 +526,21 @@
       content: '';
       position: absolute;
       top: calc(50% + 28px);
-      width: calc(50% - 210px);
-      height: 4px;
-      background: linear-gradient(90deg, transparent, rgba(0, 255, 102, 0.92) 38%, rgba(0, 194, 255, 0.96));
-      box-shadow: 0 0 16px rgba(0, 255, 102, 0.78), 0 0 30px rgba(0, 194, 255, 0.44);
+      width: calc(50% - 230px);
+      height: 2px;
+      background: rgba(52, 211, 153, 0.42);
       transform: translateY(-50%);
       z-index: -1;
-      animation: connectorPulse 2.8s ease-in-out infinite;
     }
 
     .bracket-desktop::before { left: 8%; }
-    .bracket-desktop::after { right: 8%; transform: translateY(-50%) scaleX(-1); animation-delay: 1.1s; }
+    .bracket-desktop::after { right: 8%; transform: translateY(-50%); }
 
     .bracket-mobile { display: none; }
 
     .round {
       display: grid;
-      gap: 16px;
+      gap: 14px;
       position: relative;
       min-width: 0;
     }
@@ -538,31 +550,24 @@
       align-items: center;
       justify-content: space-between;
       gap: 10px;
-      min-height: 36px;
+      min-height: 34px;
       color: var(--text);
     }
 
     .round-title h3 {
       margin: 0;
-      font-size: clamp(0.72rem, 1vw, 0.92rem);
-      letter-spacing: 0.17em;
+      color: #f8fafc;
+      font-size: clamp(0.72rem, 1vw, 0.88rem);
+      letter-spacing: 0.14em;
       text-transform: uppercase;
-      text-shadow: 0 0 18px rgba(0, 194, 255, 0.24);
+      text-shadow: none;
     }
 
     .round-chip {
-      border: 1px solid rgba(0, 194, 255, 0.42);
       border-radius: 2px;
-      padding: 7px 10px;
-      color: #8be9ff;
-      font-size: 0.62rem;
-      font-weight: 950;
-      letter-spacing: 0.13em;
-      text-transform: uppercase;
-      background: rgba(0, 194, 255, 0.09);
-      box-shadow: inset 0 0 18px rgba(0, 194, 255, 0.08), 0 0 16px rgba(0, 194, 255, 0.12);
       white-space: nowrap;
-      clip-path: polygon(9px 0, 100% 0, 100% calc(100% - 9px), calc(100% - 9px) 100%, 0 100%, 0 9px);
+      box-shadow: none;
+      clip-path: none;
     }
 
     .matchup-card {
@@ -570,97 +575,75 @@
       display: grid;
       gap: 8px;
       min-height: 132px;
-      border: 1px solid rgba(0, 194, 255, 0.38);
-      border-radius: 3px;
-      padding: 12px;
-      background:
-        linear-gradient(90deg, rgba(0, 255, 102, 0.12), transparent 24%, rgba(0, 194, 255, 0.1)),
-        linear-gradient(145deg, rgba(8, 14, 26, 0.98), rgba(1, 4, 12, 0.92));
-      box-shadow:
-        inset 0 0 0 1px rgba(255, 255, 255, 0.035),
-        inset 0 0 34px rgba(0, 194, 255, 0.06),
-        0 18px 44px rgba(0, 0, 0, 0.34);
-      clip-path: polygon(18px 0, 100% 0, 100% calc(100% - 18px), calc(100% - 18px) 100%, 0 100%, 0 18px);
-      transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      border-left: 3px solid rgba(52, 211, 153, 0.72);
+      border-radius: 2px;
+      padding: 10px;
+      background: #121821;
+      box-shadow: 0 12px 28px rgba(0, 0, 0, 0.28);
+      clip-path: none;
+      transition: border-color 140ms ease, background 140ms ease;
     }
 
     .matchup-card:hover {
-      border-color: rgba(0, 255, 102, 0.82);
-      box-shadow:
-        inset 0 0 0 1px rgba(0, 255, 102, 0.18),
-        inset 0 0 42px rgba(0, 194, 255, 0.12),
-        0 0 26px rgba(0, 255, 102, 0.22),
-        0 18px 48px rgba(0, 0, 0, 0.4);
-      transform: translateY(-3px);
+      border-color: rgba(52, 211, 153, 0.5);
+      background: #151d27;
+      transform: none;
+      box-shadow: 0 12px 28px rgba(0, 0, 0, 0.3);
     }
 
-    .matchup-card::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background:
-        linear-gradient(120deg, rgba(0, 255, 102, 0.72), rgba(0, 194, 255, 0), rgba(255, 61, 242, 0.38)) border-box;
-      opacity: 0.32;
-      pointer-events: none;
-      clip-path: inherit;
-    }
+    .matchup-card::before { display: none; }
 
     .matchup-card::after {
       content: '';
       position: absolute;
       top: 50%;
-      right: -30px;
-      width: 30px;
-      height: 4px;
-      background: linear-gradient(90deg, rgba(0, 255, 102, 0.95), rgba(0, 194, 255, 0.95));
-      box-shadow: 0 0 16px rgba(0, 255, 102, 0.82), 0 0 20px rgba(0, 194, 255, 0.5);
-      animation: connectorPulse 2.4s ease-in-out infinite;
+      right: -25px;
+      width: 25px;
+      height: 2px;
+      background: rgba(52, 211, 153, 0.42);
     }
 
     .west-final .matchup-card::after,
     .west-semis .matchup-card::after {
       right: auto;
-      left: -30px;
-      transform: scaleX(-1);
+      left: -25px;
+      transform: none;
     }
 
     .finals .matchup-card::after { display: none; }
 
     .team-slot {
       display: grid;
-      grid-template-columns: 48px minmax(0, 1fr) auto;
+      grid-template-columns: 44px minmax(0, 1fr) auto;
       grid-template-areas:
         "logo name seed"
         "logo meta seed";
       align-items: center;
-      gap: 2px 12px;
+      gap: 2px 11px;
       min-height: 54px;
       padding: 8px 10px 8px 8px;
-      border: 1px solid rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(148, 163, 184, 0.14);
       border-radius: 2px;
-      background:
-        linear-gradient(90deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.015)),
-        rgba(255, 255, 255, 0.025);
-      font-weight: 950;
-      clip-path: polygon(10px 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%, 0 10px);
+      background: #0e131a;
+      font-weight: 900;
+      clip-path: none;
     }
 
     .team-logo {
       grid-area: logo;
       display: grid;
       place-items: center;
-      width: 48px;
+      width: 44px;
       height: 38px;
-      border: 1px solid rgba(0, 255, 102, 0.48);
+      padding: 3px;
+      border: 1px solid rgba(148, 163, 184, 0.16);
       border-radius: 2px;
-      color: #071017;
-      font-size: 0.72rem;
-      font-weight: 1000;
+      color: #dce7f2;
+      font-size: 0.68rem;
+      font-weight: 950;
       letter-spacing: -0.05em;
-      background:
-        linear-gradient(135deg, rgba(255,255,255,0.86) 0 12%, transparent 12% 22%, rgba(255,255,255,0.24) 22% 34%, transparent 34%),
-        linear-gradient(145deg, #00ff66, #00c2ff 70%);
-      box-shadow: 0 0 16px rgba(0, 255, 102, 0.34);
+      box-shadow: none;
     }
 
     .team-name {
@@ -669,7 +652,7 @@
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-      color: #f8fbff;
+      color: #ffffff;
       font-size: 0.9rem;
       letter-spacing: 0.01em;
     }
@@ -679,9 +662,9 @@
       display: flex;
       gap: 8px;
       min-width: 0;
-      color: #8ea3bb;
+      color: #95a3b5;
       font-size: 0.68rem;
-      font-weight: 850;
+      font-weight: 800;
       letter-spacing: 0.08em;
       text-transform: uppercase;
       white-space: nowrap;
@@ -697,28 +680,28 @@
       display: inline-grid;
       place-items: center;
       min-width: 42px;
-      border: 1px solid rgba(0, 255, 102, 0.64);
+      border: 1px solid rgba(52, 211, 153, 0.44);
       border-radius: 2px;
       padding: 7px 8px;
-      color: #baffcf;
-      font-size: 0.7rem;
+      color: #b7f5cf;
+      font-size: 0.68rem;
       letter-spacing: 0.08em;
       text-transform: uppercase;
-      background: rgba(0, 255, 102, 0.13);
-      box-shadow: 0 0 16px rgba(0, 255, 102, 0.18);
+      background: rgba(52, 211, 153, 0.08);
+      box-shadow: none;
       white-space: nowrap;
-      clip-path: polygon(7px 0, 100% 0, 100% calc(100% - 7px), calc(100% - 7px) 100%, 0 100%, 0 7px);
+      clip-path: none;
     }
 
     .series-label {
       justify-self: end;
       margin-top: -2px;
-      color: #00ff66;
-      font-size: 0.62rem;
-      font-weight: 950;
-      letter-spacing: 0.18em;
+      color: #8adfaf;
+      font-size: 0.6rem;
+      font-weight: 900;
+      letter-spacing: 0.16em;
       text-transform: uppercase;
-      text-shadow: 0 0 12px rgba(0, 255, 102, 0.48);
+      text-shadow: none;
     }
 
     .finals {
@@ -730,18 +713,16 @@
     .finals-emblem {
       display: grid;
       place-items: center;
-      width: 84px;
-      height: 72px;
-      margin: 0 auto 12px;
-      border: 1px solid rgba(0, 255, 102, 0.62);
+      width: 76px;
+      height: 62px;
+      margin: 0 auto 10px;
+      border: 1px solid rgba(52, 211, 153, 0.36);
       border-radius: 2px;
-      color: #00ff66;
-      font-size: 2.35rem;
-      background:
-        radial-gradient(circle, rgba(0, 255, 102, 0.22), transparent 58%),
-        linear-gradient(145deg, rgba(0, 194, 255, 0.2), rgba(255, 61, 242, 0.12));
-      box-shadow: 0 0 34px rgba(0, 255, 102, 0.26), inset 0 0 30px rgba(0, 194, 255, 0.14);
-      clip-path: polygon(16px 0, 100% 0, 100% calc(100% - 16px), calc(100% - 16px) 100%, 0 100%, 0 16px);
+      color: #9fe7bf;
+      font-size: 2rem;
+      background: #121821;
+      box-shadow: none;
+      clip-path: none;
     }
 
     .finals .round-title {
@@ -753,55 +734,29 @@
 
     .finals .round-title h3 {
       color: white;
-      font-size: clamp(1.18rem, 1.9vw, 1.55rem);
+      font-size: clamp(1.1rem, 1.7vw, 1.38rem);
     }
 
     .finals .matchup-card {
       width: min(100%, 520px);
-      min-height: 264px;
-      border-color: rgba(255, 61, 242, 0.54);
-      padding: 20px;
-      background:
-        radial-gradient(circle at 50% 0%, rgba(0, 255, 102, 0.2), transparent 42%),
-        linear-gradient(145deg, rgba(8, 20, 32, 0.98), rgba(1, 4, 12, 0.96));
-      box-shadow:
-        0 0 52px rgba(0, 255, 102, 0.22),
-        0 0 42px rgba(0, 194, 255, 0.16),
-        inset 0 0 46px rgba(255, 61, 242, 0.06);
+      min-height: 248px;
+      border-color: rgba(52, 211, 153, 0.38);
+      border-left-color: rgba(52, 211, 153, 0.82);
+      padding: 18px;
+      background: #121821;
+      box-shadow: 0 14px 30px rgba(0, 0, 0, 0.32);
     }
 
     .finals .team-slot {
-      min-height: 82px;
-      grid-template-columns: 70px minmax(0, 1fr) auto;
+      min-height: 78px;
+      grid-template-columns: 66px minmax(0, 1fr) auto;
       padding: 11px;
     }
 
-    .finals .team-logo { width: 70px; height: 56px; font-size: 0.86rem; }
-    .finals .team-name { font-size: 1.12rem; }
-    .finals .team-meta { font-size: 0.75rem; }
-    .finals .round-chip { color: #ffb8fb; border-color: rgba(255, 61, 242, 0.46); background: rgba(255, 61, 242, 0.1); }
-
-    @keyframes particleFloat {
-      from { transform: translate3d(0, 0, 0) scale(1); opacity: 0.28; }
-      50% { opacity: 0.78; }
-      to { transform: translate3d(28px, -42px, 0) scale(1.28); opacity: 0.45; }
-    }
-
-    @keyframes scanSweep {
-      0% { transform: translateX(-125%) skewX(-16deg); opacity: 0; }
-      18%, 72% { opacity: 1; }
-      100% { transform: translateX(330%) skewX(-16deg); opacity: 0; }
-    }
-
-    @keyframes gridDrift {
-      from { background-position: 0 0, 0 0; }
-      to { background-position: 42px 42px, 42px 42px; }
-    }
-
-    @keyframes connectorPulse {
-      0%, 100% { opacity: 0.42; filter: saturate(0.8); }
-      50% { opacity: 1; filter: saturate(1.45); }
-    }
+    .finals .team-logo { width: 66px; height: 54px; font-size: 0.8rem; }
+    .finals .team-name { font-size: 1.08rem; }
+    .finals .team-meta { font-size: 0.73rem; }
+    .finals .round-chip { color: #b7f5cf; border-color: rgba(52, 211, 153, 0.44); background: rgba(52, 211, 153, 0.08); }
 
     @media (max-width: 920px) {
       .league-grid { grid-template-columns: 1fr; }
@@ -818,7 +773,7 @@
         margin-left: calc(50% - 50vw + 10px);
         min-height: auto;
         padding: 18px 12px 24px;
-        border-radius: 12px;
+        border-radius: 6px;
       }
       .playoff-stage-header { margin-bottom: 22px; }
       .playoff-kicker::before,
@@ -837,12 +792,10 @@
       .timeline-round:not(:last-child)::after {
         content: '';
         justify-self: center;
-        width: 4px;
+        width: 2px;
         height: 32px;
         margin: 0 0 -6px;
-        background: linear-gradient(180deg, rgba(0, 255, 102, 0.95), rgba(0, 194, 255, 0.95));
-        box-shadow: 0 0 16px rgba(0, 255, 102, 0.8), 0 0 24px rgba(0, 194, 255, 0.5);
-        animation: connectorPulse 2.2s ease-in-out infinite;
+        background: rgba(52, 211, 153, 0.42);
       }
       .bracket-mobile .round-title { justify-content: center; text-align: center; }
       .bracket-mobile .round-chip { display: none; }
@@ -891,10 +844,6 @@
 
       <section class="tab-panel" id="playoffs-panel" aria-label="UPCL League Playoffs">
         <div class="playoff-panel">
-          <div class="particle-field" aria-hidden="true">
-            <span></span><span></span><span></span><span></span><span></span><span></span>
-            <span></span><span></span><span></span><span></span><span></span><span></span>
-          </div>
           <div class="playoff-stage-header">
             <p class="playoff-kicker">Championship Bracket</p>
             <h2>League Playoffs</h2>
@@ -934,6 +883,22 @@
         { seed: 5, team: 'FC Dhizz', pl: 10, w: 3, d: 2, l: 5, gf: 15, ga: 20, form: ['D', 'L', 'L', 'W', 'L'] },
         { seed: 6, team: 'Khalch FC', pl: 10, w: 1, d: 3, l: 6, gf: 10, ga: 24, form: ['L', 'D', 'L', 'D', 'L'] }
       ]
+    };
+
+
+    const teamLogos = {
+      'Bota FC': '/assets/logos/league-crest.png',
+      'Royal Republic': '/assets/logos/royal-republic.png',
+      'Club Frijol': '/assets/logos/club-frijol.png',
+      'AFC Warriors': '/assets/logos/afc-warriors.png',
+      'Ethabella FC': '/assets/logos/ethabella-fc.png',
+      'Rooney Tunes': '/assets/logos/rooney-tunes.png',
+      'Razorblack FC': '/assets/logos/razorblack-fc.png',
+      'Sporting de la MA': '/assets/logos/sporting-de-la-ma.png',
+      'Jids Trivela': '/assets/logos/jids-trivela.png',
+      'Elite VT': '/assets/logos/elite-vt.png',
+      'FC Dhizz': '/assets/logos/fc-dhizz.png',
+      'Khalch FC': '/assets/logos/khalch-fc.png'
     };
 
     const teamCities = {
@@ -1026,8 +991,12 @@
       matchesEl.innerHTML = '<div class="empty">No friendly matches were returned by EA yet. Try refreshing again later.</div>';
     }
 
+    function getTeamLogoPath(team) {
+      return teamLogos[team] || '/assets/logos/league-crest.png';
+    }
+
     function renderForm(form) {
-      return `<span class="form">${form.map(result => `<span class="${escapeHtml(result)}">${escapeHtml(result)}</span>`).join('')}</span>`;
+      return `<span class="form">${form.map(result => `<span class="${escapeHtml(result)}" aria-label="${escapeHtml(result)}"></span>`).join('')}</span>`;
     }
 
     function renderStandingsCard(title, chip, rows) {
@@ -1040,7 +1009,7 @@
           <div class="table-wrap">
             <table class="standings">
               <thead>
-                <tr><th>Seed</th><th>Team</th><th>PL</th><th>W</th><th>D</th><th>L</th><th>GF</th><th>GA</th><th>GD</th><th>PTS</th><th>Form</th></tr>
+                <tr><th>Seed</th><th>Club</th><th>PL</th><th>Record</th><th>GF</th><th>GA</th><th>GD</th><th>PTS</th><th>Form</th></tr>
               </thead>
               <tbody>
                 ${rows.map(row => {
@@ -1049,10 +1018,19 @@
                   const badge = row.seed <= 2 ? '<span class="badge">Playoff Spot</span>' : '';
                   return `
                     <tr class="${row.seed === 2 ? 'cutoff' : ''}">
-                      <td>${row.seed}</td>
-                      <td class="team-cell">${escapeHtml(row.team)}${badge}</td>
-                      <td>${row.pl}</td><td>${row.w}</td><td>${row.d}</td><td>${row.l}</td>
-                      <td>${row.gf}</td><td>${row.ga}</td><td>${gd > 0 ? '+' : ''}${gd}</td><td>${pts}</td>
+                      <td class="seed-cell">${row.seed}</td>
+                      <td class="team-cell">
+                        <div class="club-cell">
+                          <img class="club-logo" src="${escapeHtml(getTeamLogoPath(row.team))}" alt="" loading="lazy">
+                          <span class="club-name-wrap">
+                            <span class="club-name">${escapeHtml(row.team)}</span>
+                            ${badge}
+                          </span>
+                        </div>
+                      </td>
+                      <td>${row.pl}</td>
+                      <td class="record-cell">${row.w}-${row.d}-${row.l}</td>
+                      <td>${row.gf}</td><td>${row.ga}</td><td>${gd > 0 ? '+' : ''}${gd}</td><td class="points-cell">${pts}</td>
                       <td>${renderForm(row.form)}</td>
                     </tr>
                   `;
@@ -1062,16 +1040,6 @@
           </div>
         </article>
       `;
-    }
-
-    function getTeamInitials(team) {
-      return String(team || 'UPCL')
-        .split(/\s+/)
-        .filter(Boolean)
-        .slice(0, 2)
-        .map(word => word[0])
-        .join('')
-        .toUpperCase();
     }
 
     function getTeamRecord(team) {
@@ -1091,9 +1059,10 @@
     function renderTeamSlot(slot) {
       const enrichedSlot = enrichPlayoffSlot(slot);
       const cityMarkup = enrichedSlot.city ? `<span class="team-city">${escapeHtml(enrichedSlot.city)}</span>` : '';
+      const logoPath = getTeamLogoPath(enrichedSlot.team);
       return `
         <div class="team-slot">
-          <span class="team-logo" aria-hidden="true">${escapeHtml(getTeamInitials(enrichedSlot.team))}</span>
+          <img class="team-logo" src="${escapeHtml(logoPath)}" alt="" loading="lazy">
           <span class="team-name">${escapeHtml(enrichedSlot.team)}</span>
           <span class="team-meta"><span>${escapeHtml(enrichedSlot.record)}</span>${cityMarkup}</span>
           <span class="seed">${escapeHtml(enrichedSlot.seed)}</span>

--- a/server.js
+++ b/server.js
@@ -20,6 +20,7 @@ app.use((_req, res, next) => {
   next();
 });
 app.use(express.json({ limit: '1mb' }));
+app.use('/assets', express.static(path.join(PUBLIC_DIR, 'assets')));
 
 function toNumber(value, fallback = 0) {
   const number = Number(value);


### PR DESCRIPTION
### Motivation
- Replace the existing neon/dashboard aesthetic with a restrained, professional esports statistics visual language using dark charcoal surfaces, white typography and subtle green accents.
- Reduce heavy glow/particle/gradient effects and oversized pill shapes in the Tables and Playoffs views so spacing and hierarchy drive the UI instead of glow.

### Description
- Overhauled the Tables and Playoffs markup and styles in `public/teams.html` to use full-width conference tables, charcoal panels, tighter row spacing, compact record cells, club logo cells, circular form indicators, and cleaner table header styles.
- Reworked the playoff area in `public/teams.html` to use sharp rectangular matchup cards, broadcast/bracket connector lines, team logos, seeds and record metadata while removing particle fields, oversized gradients and glowing overlays.
- Added a `teamLogos` map and `getTeamLogoPath` helper in the client script and updated `renderStandingsCard`/`renderTeamSlot` to render club images and updated form rendering to circular indicators.
- Exposed static assets in `server.js` with `app.use('/assets', express.static(path.join(PUBLIC_DIR, 'assets')));` so logo image requests are served by the app.

### Testing
- Ran `npm test` and all unit tests passed (5 tests ✅). 
- Started the app with `npm start` and confirmed the server responded on port 3000 (server running). 
- Verified logo assets are served with `curl -I http://127.0.0.1:3000/assets/logos/club-frijol.png` which returned `200 OK`. 
- Attempted an automated screenshot via `npx --yes playwright@latest` but the environment blocked the install (npm registry `403 Forbidden`), so a headless screenshot could not be obtained here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2654c80d2c832a88c806a22e00cdf3)