### PR TITLE
Add Postgres match storage and sync routes

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,0 +1,123 @@
+let pool;
+let tableReadyPromise;
+
+function getDatabaseUrl() {
+  return process.env.DATABASE_URL;
+}
+
+function createPool() {
+  const databaseUrl = getDatabaseUrl();
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL environment variable is required for Postgres access');
+  }
+
+  // Load pg lazily so routes that do not use the database can still run in
+  // environments where dependencies have not been installed yet.
+  const { Pool } = require('pg');
+  const isLocalDatabase = /^postgres(?:ql)?:\/\/(?:[^@]+@)?(?:localhost|127\.0\.0\.1)(?::|\/)/i.test(databaseUrl);
+
+  return new Pool({
+    connectionString: databaseUrl,
+    ssl: isLocalDatabase ? false : { rejectUnauthorized: false },
+  });
+}
+
+function getPool() {
+  if (!pool) pool = createPool();
+  return pool;
+}
+
+async function query(sql, params) {
+  return getPool().query(sql, params);
+}
+
+async function ensureMatchesTable() {
+  if (!tableReadyPromise) {
+    tableReadyPromise = query(`
+      CREATE TABLE IF NOT EXISTS matches (
+        id serial PRIMARY KEY,
+        match_id text UNIQUE NOT NULL,
+        source_club_id text NOT NULL,
+        club_name text,
+        opponent_name text,
+        club_score integer,
+        opponent_score integer,
+        result text,
+        match_date timestamp,
+        raw_json jsonb,
+        created_at timestamp DEFAULT now()
+      )
+    `).catch(error => {
+      tableReadyPromise = null;
+      throw error;
+    });
+  }
+
+  return tableReadyPromise;
+}
+
+function normalizeMatchDate(timestamp) {
+  if (!timestamp) return null;
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+async function insertMatch(match, sourceClub) {
+  await ensureMatchesTable();
+  const response = await query(
+    `INSERT INTO matches (
+      match_id,
+      source_club_id,
+      club_name,
+      opponent_name,
+      club_score,
+      opponent_score,
+      result,
+      match_date,
+      raw_json
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+    ON CONFLICT (match_id) DO NOTHING
+    RETURNING id`,
+    [
+      match.id,
+      sourceClub.id,
+      match.team?.name || sourceClub.name || null,
+      match.opponent?.name || null,
+      match.score?.for ?? null,
+      match.score?.against ?? null,
+      match.result || null,
+      normalizeMatchDate(match.timestamp),
+      JSON.stringify(match.raw || match),
+    ]
+  );
+
+  return response.rowCount === 1;
+}
+
+async function getSavedMatches() {
+  await ensureMatchesTable();
+  const response = await query(`
+    SELECT
+      id,
+      match_id,
+      source_club_id,
+      club_name,
+      opponent_name,
+      club_score,
+      opponent_score,
+      result,
+      match_date,
+      raw_json,
+      created_at
+    FROM matches
+    ORDER BY match_date DESC NULLS LAST, id DESC
+  `);
+  return response.rows;
+}
+
+module.exports = {
+  ensureMatchesTable,
+  getSavedMatches,
+  insertMatch,
+  normalizeMatchDate,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
     "": {
       "name": "fc-26-project-beta",
       "dependencies": {
-        "express": "^4.19.2"
+        "express": "^4.19.2",
+        "pg": "^8.13.1"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "NODE_ENV=test node --test"
   },
   "dependencies": {
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "pg": "^8.13.1"
   }
 }

--- a/public/teams.html
+++ b/public/teams.html
@@ -134,6 +134,13 @@
       font-size: 0.95rem;
     }
 
+    .fixture-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      justify-content: flex-end;
+    }
+
     button.refresh {
       border: 1px solid var(--border);
       border-radius: 999px;
@@ -149,10 +156,14 @@
       opacity: 0.7;
     }
 
-    #matches {
+    #matches,
+    #dbMatches {
       display: grid;
       gap: 16px;
+      padding: 16px;
     }
+
+    #matches { padding: 0; }
 
     .match-card {
       display: grid;
@@ -1158,10 +1169,21 @@
             <strong id="teamLabel">Bota FC</strong>
             <div class="status" id="status">Loading friendly matches…</div>
           </div>
-          <button class="refresh" id="refresh" type="button">Refresh</button>
+          <div class="fixture-actions">
+            <button class="refresh" id="refresh" type="button">Refresh</button>
+            <button class="refresh" id="syncMatches" type="button">Sync Matches to Database</button>
+          </div>
         </section>
 
         <section id="matches" aria-label="Bota FC fixtures"></section>
+
+        <section class="standings-card" aria-label="Saved database matches">
+          <div class="section-heading">
+            <h2>Database Matches</h2>
+            <span class="conference-chip" id="dbStatus">Not loaded</span>
+          </div>
+          <section id="dbMatches" aria-label="Saved Postgres matches"></section>
+        </section>
       </section>
 
       <section class="tab-panel" id="tables-panel" aria-label="UPCL conference tables">
@@ -1186,6 +1208,9 @@
     const statusEl = document.getElementById('status');
     const teamLabelEl = document.getElementById('teamLabel');
     const refreshButton = document.getElementById('refresh');
+    const syncMatchesButton = document.getElementById('syncMatches');
+    const dbMatchesEl = document.getElementById('dbMatches');
+    const dbStatusEl = document.getElementById('dbStatus');
 
     const tabButtons = document.querySelectorAll('.tab');
     const tabPanels = document.querySelectorAll('.tab-panel');
@@ -1293,6 +1318,22 @@
             <div class="team-line"><span>${escapeHtml(opponent.name)}</span><span class="score">${scoreValue(match.score?.against)}</span></div>
           </div>
           <div class="match-id">Match ID<br>${escapeHtml(match.id)}</div>
+        </article>
+      `;
+    }
+
+    function renderDbMatch(match) {
+      return `
+        <article class="match-card">
+          <div>
+            <div class="result ${escapeHtml(match.result || '—')}">${escapeHtml(match.result || '—')}</div>
+            <div class="date">${escapeHtml(formatDate(match.match_date))}</div>
+          </div>
+          <div class="teams">
+            <div class="team-line"><span>${escapeHtml(match.club_name || `Club ${match.source_club_id}`)}</span><span class="score">${scoreValue(match.club_score)}</span></div>
+            <div class="team-line"><span>${escapeHtml(match.opponent_name || 'Opponent TBD')}</span><span class="score">${scoreValue(match.opponent_score)}</span></div>
+          </div>
+          <div class="match-id">DB Match ID<br>${escapeHtml(match.match_id)}</div>
         </article>
       `;
     }
@@ -1459,13 +1500,51 @@
       }
     }
 
+    async function loadDbMatches() {
+      dbStatusEl.textContent = 'Loading saved matches…';
+      try {
+        const response = await fetch('/api/db-matches');
+        const payload = await response.json();
+        if (!response.ok) throw new Error(payload.details || payload.error || 'Request failed');
+        const matches = Array.isArray(payload.matches) ? payload.matches : [];
+        dbStatusEl.textContent = `${matches.length} saved ${matches.length === 1 ? 'match' : 'matches'}`;
+        dbMatchesEl.innerHTML = matches.length
+          ? matches.map(renderDbMatch).join('')
+          : '<div class="empty">No matches have been saved to Postgres yet. Use the sync button to import recent EA matches.</div>';
+      } catch (error) {
+        dbStatusEl.textContent = 'Database unavailable';
+        dbMatchesEl.innerHTML = `<div class="error">Saved database matches could not be loaded: ${escapeHtml(error.message)}</div>`;
+      }
+    }
+
+    async function syncMatchesToDatabase() {
+      syncMatchesButton.disabled = true;
+      dbStatusEl.textContent = 'Syncing matches…';
+      try {
+        const response = await fetch('/api/sync-matches', { method: 'POST' });
+        const payload = await response.json();
+        if (!response.ok) throw new Error(payload.details || payload.error || 'Sync failed');
+        dbStatusEl.textContent = `${payload.inserted} inserted, ${payload.skipped} skipped`;
+        statusEl.textContent = `Database sync complete: ${payload.totalFetched} fetched, ${payload.inserted} inserted, ${payload.skipped} skipped.`;
+        await loadDbMatches();
+      } catch (error) {
+        dbStatusEl.textContent = 'Sync failed';
+        statusEl.textContent = 'Database sync failed.';
+        dbMatchesEl.innerHTML = `<div class="error">Matches could not be synced to Postgres: ${escapeHtml(error.message)}</div>`;
+      } finally {
+        syncMatchesButton.disabled = false;
+      }
+    }
+
     tabButtons.forEach(button => {
       button.addEventListener('click', () => activateTab(button.dataset.tab));
     });
 
     refreshButton.addEventListener('click', loadMatches);
+    syncMatchesButton.addEventListener('click', syncMatchesToDatabase);
     renderStaticLeagueLayers();
     loadMatches();
+    loadDbMatches();
   </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -3,19 +3,29 @@ const path = require('path');
 const fs = require('fs');
 const logger = require('./logger');
 const eaApi = require('./services/eaApi');
+const db = require('./db');
 
 const app = express();
 const PUBLIC_DIR = path.join(__dirname, 'public');
 
+const LEAGUE_CLUBS = [
+  { id: '57985', name: 'Bota FC' },
+  { id: '6297844', name: 'Inferign Utd' },
+  { id: '1171188', name: 'Egoistas' },
+  { id: '4671025', name: 'Versus One' },
+  { id: '654142', name: 'FC Wisconsin' },
+  { id: '129307', name: 'FC Sutton' },
+];
+
 const BOTA_FC = {
-  id: process.env.BOTA_CLUB_ID || '57985',
-  name: process.env.BOTA_CLUB_NAME || 'Bota FC',
+  id: process.env.BOTA_CLUB_ID || LEAGUE_CLUBS[0].id,
+  name: process.env.BOTA_CLUB_NAME || LEAGUE_CLUBS[0].name,
 };
 const ACTIVE_MATCH_TYPE = 'friendlyMatch';
 
 app.use((_req, res, next) => {
   res.set('Access-Control-Allow-Origin', '*');
-  res.set('Access-Control-Allow-Methods', 'GET,HEAD,OPTIONS');
+  res.set('Access-Control-Allow-Methods', 'GET,HEAD,POST,OPTIONS');
   res.set('Access-Control-Allow-Headers', 'Content-Type');
   next();
 });
@@ -44,8 +54,8 @@ function normalizeClub(clubId, club = {}) {
   };
 }
 
-function getMatchId(match, index) {
-  return String(match.matchId ?? match.matchid ?? match.id ?? `friendly-${index}`);
+function getMatchId(match, index, team = BOTA_FC) {
+  return String(match.matchId ?? match.matchid ?? match.id ?? `${team.id}-friendly-${index}`);
 }
 
 function normalizeMatch(match, index, team = BOTA_FC) {
@@ -62,7 +72,7 @@ function normalizeMatch(match, index, team = BOTA_FC) {
   }
 
   return {
-    id: getMatchId(match, index),
+    id: getMatchId(match, index, team),
     timestamp: normalizeTimestamp(match),
     team: bota || { id: team.id, name: team.name, goals: botaGoals, isHome: false },
     opponent,
@@ -119,6 +129,53 @@ async function sendFriendlyMatches(_req, res) {
 app.get('/api/matches', sendFriendlyMatches);
 app.get('/api/fixtures', sendFriendlyMatches);
 
+app.post('/api/sync-matches', async (_req, res) => {
+  const totals = {
+    totalFetched: 0,
+    inserted: 0,
+    skipped: 0,
+  };
+
+  try {
+    await db.ensureMatchesTable();
+
+    for (const club of LEAGUE_CLUBS) {
+      const rawMatches = await eaApi.fetchFriendlyMatches(club.id);
+      totals.totalFetched += rawMatches.length;
+
+      const matches = rawMatches.map((match, index) => normalizeMatch(match, index, club));
+      for (const match of matches) {
+        const inserted = await db.insertMatch(match, club);
+        if (inserted) totals.inserted += 1;
+        else totals.skipped += 1;
+      }
+    }
+
+    res.json(totals);
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to sync friendly matches to Postgres');
+    res.status(500).json({
+      error: 'Failed to sync friendly matches to Postgres',
+      details: error.message || 'Database sync failed',
+      ...totals,
+    });
+  }
+});
+
+app.get('/api/db-matches', async (_req, res) => {
+  try {
+    const matches = await db.getSavedMatches();
+    res.json({ matches });
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to load saved matches from Postgres');
+    res.status(500).json({
+      error: 'Failed to load saved matches from Postgres',
+      details: error.message || 'Database query failed',
+      matches: [],
+    });
+  }
+});
+
 if (require.main === module) {
   const port = process.env.PORT || 3000;
   app.listen(port, () => {
@@ -130,3 +187,4 @@ module.exports = app;
 module.exports.normalizeMatch = normalizeMatch;
 module.exports.normalizeTimestamp = normalizeTimestamp;
 module.exports.BOTA_FC = BOTA_FC;
+module.exports.LEAGUE_CLUBS = LEAGUE_CLUBS;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -68,3 +68,62 @@ test('GET /api/matches returns friendly matches for Bota FC', async () => {
 
   fetchStub.mock.restore();
 });
+
+test('POST /api/sync-matches stores recent matches for all league clubs', async () => {
+  const db = require('../db');
+  const fetchedClubIds = [];
+  const insertedMatches = [];
+  const fetchStub = mock.method(eaApi, 'fetchFriendlyMatches', async clubId => {
+    fetchedClubIds.push(clubId);
+    return [
+      {
+        matchId: `match-${clubId}`,
+        timestamp: 1_700_000_000,
+        clubs: {
+          [clubId]: { goals: 2, details: { name: `Club ${clubId}` } },
+          999: { goals: 1, details: { name: 'Opponent FC' } },
+        },
+      },
+    ];
+  });
+  const ensureStub = mock.method(db, 'ensureMatchesTable', async () => {});
+  const insertStub = mock.method(db, 'insertMatch', async (match, club) => {
+    insertedMatches.push({ match, club });
+    return insertedMatches.length % 2 === 1;
+  });
+
+  await withServer(async port => {
+    const response = await fetch(`http://localhost:${port}/api/sync-matches`, { method: 'POST' });
+    const body = await response.json();
+    assert.equal(response.status, 200);
+    assert.deepEqual(body, { totalFetched: 6, inserted: 3, skipped: 3 });
+  });
+
+  assert.deepEqual(fetchedClubIds, app.LEAGUE_CLUBS.map(club => club.id));
+  assert.equal(ensureStub.mock.callCount(), 1);
+  assert.equal(insertStub.mock.callCount(), 6);
+  assert.equal(insertedMatches[0].club.name, 'Bota FC');
+  assert.equal(insertedMatches[0].match.id, 'match-57985');
+
+  fetchStub.mock.restore();
+  ensureStub.mock.restore();
+  insertStub.mock.restore();
+});
+
+test('GET /api/db-matches returns saved Postgres matches', async () => {
+  const db = require('../db');
+  const getStub = mock.method(db, 'getSavedMatches', async () => [
+    { match_id: 'newer', match_date: '2026-01-02T00:00:00.000Z' },
+    { match_id: 'older', match_date: '2026-01-01T00:00:00.000Z' },
+  ]);
+
+  await withServer(async port => {
+    const response = await fetch(`http://localhost:${port}/api/db-matches`);
+    const body = await response.json();
+    assert.equal(response.status, 200);
+    assert.deepEqual(body.matches.map(match => match.match_id), ['newer', 'older']);
+  });
+
+  assert.equal(getStub.mock.callCount(), 1);
+  getStub.mock.restore();
+});


### PR DESCRIPTION
### Motivation
- Persist recent EA friendly matches for six league clubs into a Postgres database using the existing `DATABASE_URL` environment variable. 
- Provide a one-click sync from the Fixtures UI while keeping the current EA API display and not calculating standings yet. 

### Description
- Add `db.js` which lazily loads `pg`, creates a connection pool from `DATABASE_URL`, ensures a `matches` table exists, and exposes `insertMatch`, `getSavedMatches`, and `ensureMatchesTable` helpers. 
- Add backend endpoints `POST /api/sync-matches` to fetch matches for all six `LEAGUE_CLUBS` and insert them (skipping duplicates via `ON CONFLICT (match_id) DO NOTHING`) and `GET /api/db-matches` to return saved matches ordered by `match_date` desc. 
- Update `server.js` to add `LEAGUE_CLUBS`, call the DB helpers from the new routes, and tweak match id generation to include the source club id for uniqueness. 
- Update frontend `public/teams.html` to add a temporary “Sync Matches to Database” button, a database matches panel, and client-side functions `syncMatchesToDatabase` and `loadDbMatches` to call the new endpoints and render results. 
- Add `pg` to `package.json` and update `package-lock.json`, and add tests in `test/server.test.js` to cover the new routes and DB integration points (using stubs/mocks). 

### Testing
- Ran unit tests with `npm test` which executed the EA API and server tests and all tests passed (7/7 passing). 
- Added tests covering `POST /api/sync-matches` and `GET /api/db-matches`, and the new tests passed under the test harness. 
- Attempting to install `pg` (`npm install pg` / `npm ci --dry-run`) was blocked by the environment registry policy returning a 403, so package installation could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a267ea0483c832ab6710047c0aef873)