### PR TITLE
Build standings from saved Postgres matches

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -1064,12 +1064,12 @@
                 <div class="snapshot-stat">
                   <span class="stat-label">Eastern Clubs</span>
                   <span class="stat-value">3</span>
-                  <span class="stat-note">Bota FC, Inferign Utd, and Egoistas are set for preseason league play.</span>
+                  <span class="stat-note">Bota FC, Inferign United, and True Egoistas are set for preseason league play.</span>
                 </div>
                 <div class="snapshot-stat">
                   <span class="stat-label">Western Clubs</span>
                   <span class="stat-value">3</span>
-                  <span class="stat-note">Versus One, FC Wisconsin, and FC Sutton are set for preseason league play.</span>
+                  <span class="stat-note">Versus One, FC Wisconsin, and FC Sutton St are set for preseason league play.</span>
                 </div>
                 <div class="snapshot-stat">
                   <span class="stat-label">Playoff Cut</span>
@@ -1093,7 +1093,7 @@
                 <div class="result-row">
                   <div class="overview-team"><img src="/assets/logos/league-crest.png" alt="" loading="lazy"><span>Bota FC</span></div>
                   <div class="overview-score">—<small>No result</small></div>
-                  <div class="overview-team"><span>Inferign Utd</span><img src="/assets/logos/league-crest.png" alt="" loading="lazy"></div>
+                  <div class="overview-team"><span>Inferign United</span><img src="/assets/logos/league-crest.png" alt="" loading="lazy"></div>
                 </div>
                 <div class="result-row">
                   <div class="overview-team"><img src="/assets/logos/league-crest.png" alt="" loading="lazy"><span>Versus One</span></div>
@@ -1101,9 +1101,9 @@
                   <div class="overview-team"><span>FC Wisconsin</span><img src="/assets/logos/league-crest.png" alt="" loading="lazy"></div>
                 </div>
                 <div class="result-row">
-                  <div class="overview-team"><img src="/assets/logos/league-crest.png" alt="" loading="lazy"><span>Egoistas</span></div>
+                  <div class="overview-team"><img src="/assets/logos/league-crest.png" alt="" loading="lazy"><span>True Egoistas</span></div>
                   <div class="overview-score">—<small>No result</small></div>
-                  <div class="overview-team"><span>FC Sutton</span><img src="/assets/logos/league-crest.png" alt="" loading="lazy"></div>
+                  <div class="overview-team"><span>FC Sutton St</span><img src="/assets/logos/league-crest.png" alt="" loading="lazy"></div>
                 </div>
               </div>
             </article>
@@ -1117,17 +1117,17 @@
                 <div class="fixture-row">
                   <div class="overview-team"><img src="/assets/logos/league-crest.png" alt="" loading="lazy"><span>Bota FC</span></div>
                   <div class="fixture-date">TBD<small>Preseason</small></div>
-                  <div class="overview-team"><span>Egoistas</span><img src="/assets/logos/league-crest.png" alt="" loading="lazy"></div>
+                  <div class="overview-team"><span>True Egoistas</span><img src="/assets/logos/league-crest.png" alt="" loading="lazy"></div>
                 </div>
                 <div class="fixture-row">
-                  <div class="overview-team"><img src="/assets/logos/league-crest.png" alt="" loading="lazy"><span>Inferign Utd</span></div>
+                  <div class="overview-team"><img src="/assets/logos/league-crest.png" alt="" loading="lazy"><span>Inferign United</span></div>
                   <div class="fixture-date">TBD<small>Preseason</small></div>
                   <div class="overview-team"><span>Versus One</span><img src="/assets/logos/league-crest.png" alt="" loading="lazy"></div>
                 </div>
                 <div class="fixture-row">
                   <div class="overview-team"><img src="/assets/logos/league-crest.png" alt="" loading="lazy"><span>FC Wisconsin</span></div>
                   <div class="fixture-date">TBD<small>Preseason</small></div>
-                  <div class="overview-team"><span>FC Sutton</span><img src="/assets/logos/league-crest.png" alt="" loading="lazy"></div>
+                  <div class="overview-team"><span>FC Sutton St</span><img src="/assets/logos/league-crest.png" alt="" loading="lazy"></div>
                 </div>
               </div>
             </article>
@@ -1154,8 +1154,8 @@
               </div>
               <div class="news-feed" aria-label="UPCL preseason notes feed">
                 <article class="news-card"><span class="news-icon" aria-hidden="true">📋</span><div class="news-content"><p class="news-headline">The UPCL table has been reset for the six confirmed clubs.</p><div class="news-meta"><span class="news-category">League Office</span><span class="news-time">Preseason</span></div></div></article>
-                <article class="news-card"><span class="news-icon" aria-hidden="true">🌅</span><div class="news-content"><p class="news-headline">Eastern Conference entries: Bota FC, Inferign Utd, and Egoistas.</p><div class="news-meta"><span class="news-category">East</span><span class="news-time">Preseason</span></div></div></article>
-                <article class="news-card"><span class="news-icon" aria-hidden="true">🌄</span><div class="news-content"><p class="news-headline">Western Conference entries: Versus One, FC Wisconsin, and FC Sutton.</p><div class="news-meta"><span class="news-category">West</span><span class="news-time">Preseason</span></div></div></article>
+                <article class="news-card"><span class="news-icon" aria-hidden="true">🌅</span><div class="news-content"><p class="news-headline">Eastern Conference entries: Bota FC, Inferign United, and True Egoistas.</p><div class="news-meta"><span class="news-category">East</span><span class="news-time">Preseason</span></div></div></article>
+                <article class="news-card"><span class="news-icon" aria-hidden="true">🌄</span><div class="news-content"><p class="news-headline">Western Conference entries: Versus One, FC Wisconsin, and FC Sutton St.</p><div class="news-meta"><span class="news-category">West</span><span class="news-time">Preseason</span></div></div></article>
                 <article class="news-card"><span class="news-icon" aria-hidden="true">🧾</span><div class="news-content"><p class="news-headline">No fake standings, form, or scorelines are listed before official results arrive.</p><div class="news-meta"><span class="news-category">Tables</span><span class="news-time">Preseason</span></div></div></article>
               </div>
             </section>
@@ -1217,35 +1217,30 @@
     const standingsEl = document.getElementById('standings');
     const playoffBracketEl = document.getElementById('playoffBracket');
 
-    const standingsData = {
-      east: [
-        { seed: 1, id: '57985', team: 'Bota FC', pl: 0, w: 0, d: 0, l: 0, gf: 0, ga: 0, form: [] },
-        { seed: 2, id: '6297844', team: 'Inferign Utd', pl: 0, w: 0, d: 0, l: 0, gf: 0, ga: 0, form: [] },
-        { seed: 3, id: '1171188', team: 'Egoistas', pl: 0, w: 0, d: 0, l: 0, gf: 0, ga: 0, form: [] }
-      ],
-      west: [
-        { seed: 1, id: '4671025', team: 'Versus One', pl: 0, w: 0, d: 0, l: 0, gf: 0, ga: 0, form: [] },
-        { seed: 2, id: '654142', team: 'FC Wisconsin', pl: 0, w: 0, d: 0, l: 0, gf: 0, ga: 0, form: [] },
-        { seed: 3, id: '129307', team: 'FC Sutton', pl: 0, w: 0, d: 0, l: 0, gf: 0, ga: 0, form: [] }
-      ]
-    };
+    let standingsData = { east: [], west: [] };
 
 
     const teamLogos = {
       'Bota FC': '/assets/logos/league-crest.png',
+      'Inferign United': '/assets/logos/league-crest.png',
       'Inferign Utd': '/assets/logos/league-crest.png',
+      'True Egoistas': '/assets/logos/league-crest.png',
       'Egoistas': '/assets/logos/league-crest.png',
       'Versus One': '/assets/logos/league-crest.png',
       'FC Wisconsin': '/assets/logos/league-crest.png',
+      'FC Sutton St': '/assets/logos/league-crest.png',
       'FC Sutton': '/assets/logos/league-crest.png'
     };
 
     const teamCities = {
       'Bota FC': 'Club ID 57985',
+      'Inferign United': 'Club ID 6297844',
       'Inferign Utd': 'Club ID 6297844',
+      'True Egoistas': 'Club ID 1171188',
       'Egoistas': 'Club ID 1171188',
       'Versus One': 'Club ID 4671025',
       'FC Wisconsin': 'Club ID 654142',
+      'FC Sutton St': 'Club ID 129307',
       'FC Sutton': 'Club ID 129307'
     };
 
@@ -1254,7 +1249,7 @@
         title: 'Eastern Play-In',
         className: 'east-semis',
         matchups: [
-          [{ seed: '#2', team: 'Inferign Utd' }, { seed: '#3', team: 'Egoistas' }]
+          [{ seed: '#2', team: 'Inferign United' }, { seed: '#3', team: 'True Egoistas' }]
         ]
       },
       eastFinals: {
@@ -1276,7 +1271,7 @@
         title: 'Western Play-In',
         className: 'west-semis',
         matchups: [
-          [{ seed: '#2', team: 'FC Wisconsin' }, { seed: '#3', team: 'FC Sutton' }]
+          [{ seed: '#2', team: 'FC Wisconsin' }, { seed: '#3', team: 'FC Sutton St' }]
         ]
       }
     };
@@ -1364,8 +1359,8 @@
               </thead>
               <tbody>
                 ${rows.map(row => {
-                  const gd = row.gf - row.ga;
-                  const pts = (row.w * 3) + row.d;
+                  const gd = Number.isFinite(Number(row.gd)) ? Number(row.gd) : row.gf - row.ga;
+                  const pts = Number.isFinite(Number(row.pts)) ? Number(row.pts) : (row.w * 3) + row.d;
                   const badge = row.seed <= 2 ? '<span class="badge">Playoff Spot</span>' : '';
                   return `
                     <tr class="${row.seed === 2 ? 'cutoff' : ''}">
@@ -1465,7 +1460,7 @@
       `;
     }
 
-    function renderStaticLeagueLayers() {
+    function renderLeagueLayers() {
       standingsEl.innerHTML = [
         renderStandingsCard('Eastern Conference', 'Top 2 qualify', standingsData.east),
         renderStandingsCard('Western Conference', 'Top 2 qualify', standingsData.west)
@@ -1474,11 +1469,33 @@
       playoffBracketEl.innerHTML = renderPlayoffBracket();
     }
 
+    function renderStandingsLoading(message = 'Loading standings from saved Postgres matches…') {
+      standingsEl.innerHTML = `<div class="empty">${escapeHtml(message)}</div>`;
+      playoffBracketEl.innerHTML = renderPlayoffBracket();
+    }
+
     function activateTab(tabName) {
       tabButtons.forEach(button => button.classList.toggle('active', button.dataset.tab === tabName));
       tabPanels.forEach(panel => panel.classList.toggle('active', panel.id === `${tabName}-panel`));
     }
 
+
+    async function loadStandings() {
+      renderStandingsLoading();
+      try {
+        const response = await fetch('/api/standings');
+        const payload = await response.json();
+        if (!response.ok) throw new Error(payload.details || payload.error || 'Request failed');
+        standingsData = {
+          east: Array.isArray(payload.east) ? payload.east : [],
+          west: Array.isArray(payload.west) ? payload.west : []
+        };
+        renderLeagueLayers();
+      } catch (error) {
+        standingsEl.innerHTML = `<div class="error">Standings could not be loaded from saved database matches: ${escapeHtml(error.message)}</div>`;
+        playoffBracketEl.innerHTML = renderPlayoffBracket();
+      }
+    }
 
     async function loadMatches() {
       refreshButton.disabled = true;
@@ -1527,6 +1544,7 @@
         dbStatusEl.textContent = `${payload.inserted} inserted, ${payload.skipped} skipped`;
         statusEl.textContent = `Database sync complete: ${payload.totalFetched} fetched, ${payload.inserted} inserted, ${payload.skipped} skipped.`;
         await loadDbMatches();
+        await loadStandings();
       } catch (error) {
         dbStatusEl.textContent = 'Sync failed';
         statusEl.textContent = 'Database sync failed.';
@@ -1542,9 +1560,10 @@
 
     refreshButton.addEventListener('click', loadMatches);
     syncMatchesButton.addEventListener('click', syncMatchesToDatabase);
-    renderStaticLeagueLayers();
+    renderStandingsLoading();
     loadMatches();
     loadDbMatches();
+    loadStandings();
   </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -9,12 +9,12 @@ const app = express();
 const PUBLIC_DIR = path.join(__dirname, 'public');
 
 const LEAGUE_CLUBS = [
-  { id: '57985', name: 'Bota FC' },
-  { id: '6297844', name: 'Inferign Utd' },
-  { id: '1171188', name: 'Egoistas' },
-  { id: '4671025', name: 'Versus One' },
-  { id: '654142', name: 'FC Wisconsin' },
-  { id: '129307', name: 'FC Sutton' },
+  { id: '57985', name: 'Bota FC', conference: 'east', aliases: ['Bota FC'] },
+  { id: '6297844', name: 'Inferign United', conference: 'east', aliases: ['Inferign United', 'Inferign Utd'] },
+  { id: '1171188', name: 'True Egoistas', conference: 'east', aliases: ['True Egoistas', 'Egoistas'] },
+  { id: '4671025', name: 'Versus One', conference: 'west', aliases: ['Versus One'] },
+  { id: '654142', name: 'FC Wisconsin', conference: 'west', aliases: ['FC Wisconsin'] },
+  { id: '129307', name: 'FC Sutton St', conference: 'west', aliases: ['FC Sutton St', 'FC Sutton'] },
 ];
 
 const BOTA_FC = {
@@ -88,6 +88,108 @@ function normalizeMatch(match, index, team = BOTA_FC) {
 
 function sortMatches(matches) {
   return [...matches].sort((a, b) => toNumber(b.timestamp, 0) - toNumber(a.timestamp, 0));
+}
+
+const CLUB_BY_ID = new Map(LEAGUE_CLUBS.map(club => [club.id, club]));
+const CLUB_BY_NORMALIZED_NAME = new Map(
+  LEAGUE_CLUBS.flatMap(club => [club.name, ...(club.aliases || [])].map(name => [normalizeTeamName(name), club]))
+);
+
+function normalizeTeamName(name) {
+  return String(name || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\butd\b/g, 'united')
+    .replace(/\bst\b/g, 'st')
+    .replace(/\s+/g, ' ');
+}
+
+function findLeagueClub(id, name) {
+  const idMatch = id === null || id === undefined ? null : CLUB_BY_ID.get(String(id));
+  if (idMatch) return idMatch;
+  return CLUB_BY_NORMALIZED_NAME.get(normalizeTeamName(name)) || null;
+}
+
+function createEmptyStanding(club, seed = 0) {
+  return {
+    seed,
+    id: club.id,
+    team: club.name,
+    conference: club.conference,
+    pl: 0,
+    w: 0,
+    d: 0,
+    l: 0,
+    gf: 0,
+    ga: 0,
+    gd: 0,
+    pts: 0,
+    form: [],
+  };
+}
+
+function getMatchSortTime(match) {
+  const rawDate = match.match_date || match.created_at;
+  const dateTime = rawDate ? new Date(rawDate).getTime() : NaN;
+  return Number.isFinite(dateTime) ? dateTime : toNumber(match.id, 0);
+}
+
+function addStandingResult(row, goalsFor, goalsAgainst, result) {
+  row.pl += 1;
+  row.gf += goalsFor;
+  row.ga += goalsAgainst;
+
+  if (result === 'W') {
+    row.w += 1;
+    row.pts += 3;
+  } else if (result === 'L') {
+    row.l += 1;
+  } else {
+    row.d += 1;
+    row.pts += 1;
+  }
+}
+
+function calculateStandings(savedMatches = []) {
+  const rowsByClubId = new Map(LEAGUE_CLUBS.map(club => [club.id, createEmptyStanding(club)]));
+  const formByClubId = new Map(LEAGUE_CLUBS.map(club => [club.id, []]));
+
+  for (const match of savedMatches) {
+    const homeClub = findLeagueClub(match.source_club_id, match.club_name);
+    const awayClub = findLeagueClub(null, match.opponent_name);
+    const clubScore = Number(match.club_score);
+    const opponentScore = Number(match.opponent_score);
+
+    if (!homeClub || !awayClub || homeClub.id === awayClub.id) continue;
+    if (!Number.isFinite(clubScore) || !Number.isFinite(opponentScore)) continue;
+
+    const homeResult = clubScore > opponentScore ? 'W' : clubScore < opponentScore ? 'L' : 'D';
+    const awayResult = homeResult === 'W' ? 'L' : homeResult === 'L' ? 'W' : 'D';
+    const sortTime = getMatchSortTime(match);
+
+    addStandingResult(rowsByClubId.get(homeClub.id), clubScore, opponentScore, homeResult);
+    addStandingResult(rowsByClubId.get(awayClub.id), opponentScore, clubScore, awayResult);
+    formByClubId.get(homeClub.id).push({ result: homeResult, sortTime });
+    formByClubId.get(awayClub.id).push({ result: awayResult, sortTime });
+  }
+
+  for (const row of rowsByClubId.values()) {
+    row.gd = row.gf - row.ga;
+    row.form = formByClubId
+      .get(row.id)
+      .sort((a, b) => b.sortTime - a.sortTime)
+      .slice(0, 5)
+      .map(item => item.result);
+  }
+
+  const sortRows = rows => rows
+    .sort((a, b) => b.pts - a.pts || b.gd - a.gd || b.gf - a.gf || a.team.localeCompare(b.team))
+    .map((row, index) => ({ ...row, seed: index + 1 }));
+
+  return {
+    east: sortRows([...rowsByClubId.values()].filter(row => row.conference === 'east')),
+    west: sortRows([...rowsByClubId.values()].filter(row => row.conference === 'west')),
+  };
 }
 
 app.get('/', (_req, res) => {
@@ -176,6 +278,22 @@ app.get('/api/db-matches', async (_req, res) => {
   }
 });
 
+
+app.get('/api/standings', async (_req, res) => {
+  try {
+    const matches = await db.getSavedMatches();
+    res.json(calculateStandings(matches));
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to build standings from Postgres matches');
+    res.status(500).json({
+      error: 'Failed to build standings from Postgres matches',
+      details: error.message || 'Database query failed',
+      east: [],
+      west: [],
+    });
+  }
+});
+
 if (require.main === module) {
   const port = process.env.PORT || 3000;
   app.listen(port, () => {
@@ -188,3 +306,5 @@ module.exports.normalizeMatch = normalizeMatch;
 module.exports.normalizeTimestamp = normalizeTimestamp;
 module.exports.BOTA_FC = BOTA_FC;
 module.exports.LEAGUE_CLUBS = LEAGUE_CLUBS;
+module.exports.calculateStandings = calculateStandings;
+module.exports.findLeagueClub = findLeagueClub;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -127,3 +127,91 @@ test('GET /api/db-matches returns saved Postgres matches', async () => {
   assert.equal(getStub.mock.callCount(), 1);
   getStub.mock.restore();
 });
+
+test('calculateStandings builds conference tables from saved league matches only', () => {
+  const standings = app.calculateStandings([
+    {
+      id: 1,
+      source_club_id: '57985',
+      club_name: 'Bota FC',
+      opponent_name: 'Inferign Utd',
+      club_score: 3,
+      opponent_score: 1,
+      match_date: '2026-01-01T00:00:00.000Z',
+    },
+    {
+      id: 2,
+      source_club_id: '1171188',
+      club_name: 'Egoistas',
+      opponent_name: 'Bota FC',
+      club_score: 2,
+      opponent_score: 2,
+      match_date: '2026-01-02T00:00:00.000Z',
+    },
+    {
+      id: 3,
+      source_club_id: '4671025',
+      club_name: 'Versus One',
+      opponent_name: 'FC Wisconsin',
+      club_score: 0,
+      opponent_score: 1,
+      match_date: '2026-01-03T00:00:00.000Z',
+    },
+    {
+      id: 4,
+      source_club_id: '57985',
+      club_name: 'Bota FC',
+      opponent_name: 'Non League FC',
+      club_score: 9,
+      opponent_score: 0,
+      match_date: '2026-01-04T00:00:00.000Z',
+    },
+  ]);
+
+  assert.deepEqual(standings.east.map(row => row.team), ['Bota FC', 'True Egoistas', 'Inferign United']);
+  assert.deepEqual(standings.west.map(row => row.team), ['FC Wisconsin', 'FC Sutton St', 'Versus One']);
+
+  const bota = standings.east[0];
+  assert.equal(bota.pl, 2);
+  assert.equal(bota.w, 1);
+  assert.equal(bota.d, 1);
+  assert.equal(bota.l, 0);
+  assert.equal(bota.gf, 5);
+  assert.equal(bota.ga, 3);
+  assert.equal(bota.gd, 2);
+  assert.equal(bota.pts, 4);
+  assert.deepEqual(bota.form, ['D', 'W']);
+
+  const sutton = standings.west.find(row => row.team === 'FC Sutton St');
+  assert.equal(sutton.pl, 0);
+  assert.equal(sutton.pts, 0);
+});
+
+test('GET /api/standings returns calculated standings from saved Postgres matches', async () => {
+  const db = require('../db');
+  const getStub = mock.method(db, 'getSavedMatches', async () => [
+    {
+      id: 1,
+      source_club_id: '57985',
+      club_name: 'Bota FC',
+      opponent_name: 'Inferign United',
+      club_score: 1,
+      opponent_score: 0,
+      match_date: '2026-01-01T00:00:00.000Z',
+    },
+  ]);
+
+  await withServer(async port => {
+    const response = await fetch(`http://localhost:${port}/api/standings`);
+    const body = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(body.east.length, 3);
+    assert.equal(body.west.length, 3);
+    assert.equal(body.east[0].team, 'Bota FC');
+    assert.equal(body.east[0].pts, 3);
+    assert.equal(body.east[0].form[0], 'W');
+  });
+
+  assert.equal(getStub.mock.callCount(), 1);
+  getStub.mock.restore();
+});


### PR DESCRIPTION
### Motivation
- Replace the previous fake/static standings with real league tables built from saved `matches` rows in Postgres and ensure only league clubs are counted. 
- Surface those real standings in the Tables tab and refresh them after a database sync, avoiding any live EA API standings calculation.

### Description
- Add canonical `LEAGUE_CLUBS` metadata with `conference` and `aliases` to map legacy club names/IDs to the six league clubs. 
- Implement `calculateStandings(savedMatches)` in `server.js` to compute PL, W, D, L, GF, GA, GD, PTS and last-5 `form`, only counting matches where both participants are league clubs, and sort by `PTS`, `GD`, `GF`, then team name. 
- Add `GET /api/standings` which loads saved rows via `db.getSavedMatches()` and returns `{ east, west }` from `calculateStandings`. 
- Update `public/teams.html` to fetch `/api/standings`, render a loading/error state, display backend-provided PTS/GD values and `form`, and refresh standings after `/api/sync-matches`. 
- Export `calculateStandings` and `findLeagueClub` for testing and add handling in client code for renamed clubs (e.g. `Inferign Utd` -> `Inferign United`).

### Testing
- Ran the automated test suite with `npm test` and all tests passed (`9` tests, `0` failures). 
- Added unit tests for `calculateStandings` and the `GET /api/standings` route which passed. 
- Validated the client script by parsing/executing the page `<script>` via `new Function(...)` to catch syntax issues and confirmed it runs without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a268195d5e8832a99a25420013515a5)