### PR TITLE
Add match approval workflow for synced EA matches

### DIFF
--- a/db.js
+++ b/db.js
@@ -33,21 +33,40 @@ async function query(sql, params) {
 
 async function ensureMatchesTable() {
   if (!tableReadyPromise) {
-    tableReadyPromise = query(`
-      CREATE TABLE IF NOT EXISTS matches (
-        id serial PRIMARY KEY,
-        match_id text UNIQUE NOT NULL,
-        source_club_id text NOT NULL,
-        club_name text,
-        opponent_name text,
-        club_score integer,
-        opponent_score integer,
-        result text,
-        match_date timestamp,
-        raw_json jsonb,
-        created_at timestamp DEFAULT now()
-      )
-    `).catch(error => {
+    tableReadyPromise = (async () => {
+      await query(`
+        CREATE TABLE IF NOT EXISTS matches (
+          id serial PRIMARY KEY,
+          match_id text UNIQUE NOT NULL,
+          source_club_id text NOT NULL,
+          club_name text,
+          opponent_name text,
+          club_score integer,
+          opponent_score integer,
+          result text,
+          match_date timestamp,
+          raw_json jsonb,
+          created_at timestamp DEFAULT now()
+        )
+      `);
+
+      await query(`
+        ALTER TABLE matches
+          ADD COLUMN IF NOT EXISTS status text DEFAULT 'pending',
+          ADD COLUMN IF NOT EXISTS competition text DEFAULT 'friendly',
+          ADD COLUMN IF NOT EXISTS matchday integer,
+          ADD COLUMN IF NOT EXISTS series_id text,
+          ADD COLUMN IF NOT EXISTS notes text
+      `);
+
+      await query(`
+        UPDATE matches
+        SET
+          status = COALESCE(status, 'pending'),
+          competition = COALESCE(competition, 'friendly')
+        WHERE status IS NULL OR competition IS NULL
+      `);
+    })().catch(error => {
       tableReadyPromise = null;
       throw error;
     });
@@ -62,6 +81,27 @@ function normalizeMatchDate(timestamp) {
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
+function mapMatchRowColumns() {
+  return `
+    id,
+    match_id,
+    source_club_id,
+    club_name,
+    opponent_name,
+    club_score,
+    opponent_score,
+    result,
+    match_date,
+    raw_json,
+    created_at,
+    status,
+    competition,
+    matchday,
+    series_id,
+    notes
+  `;
+}
+
 async function insertMatch(match, sourceClub) {
   await ensureMatchesTable();
   const response = await query(
@@ -74,8 +114,10 @@ async function insertMatch(match, sourceClub) {
       opponent_score,
       result,
       match_date,
-      raw_json
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      raw_json,
+      status,
+      competition
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'pending', 'friendly')
     ON CONFLICT (match_id) DO NOTHING
     RETURNING id`,
     [
@@ -97,27 +139,90 @@ async function insertMatch(match, sourceClub) {
 async function getSavedMatches() {
   await ensureMatchesTable();
   const response = await query(`
-    SELECT
-      id,
-      match_id,
-      source_club_id,
-      club_name,
-      opponent_name,
-      club_score,
-      opponent_score,
-      result,
-      match_date,
-      raw_json,
-      created_at
+    SELECT ${mapMatchRowColumns()}
     FROM matches
     ORDER BY match_date DESC NULLS LAST, id DESC
   `);
   return response.rows;
 }
 
+async function getApprovedLeagueMatches() {
+  await ensureMatchesTable();
+  const response = await query(`
+    SELECT ${mapMatchRowColumns()}
+    FROM matches
+    WHERE status = 'approved'
+      AND competition = 'league'
+    ORDER BY match_date DESC NULLS LAST, id DESC
+  `);
+  return response.rows;
+}
+
+async function getPendingMatches() {
+  await ensureMatchesTable();
+  const response = await query(`
+    SELECT ${mapMatchRowColumns()}
+    FROM matches
+    WHERE status = 'pending'
+    ORDER BY match_date DESC NULLS LAST, id DESC
+  `);
+  return response.rows;
+}
+
+function normalizeMatchday(matchday) {
+  if (matchday === null || matchday === undefined || matchday === '') return null;
+  const number = Number(matchday);
+  if (!Number.isInteger(number) || number < 1) {
+    throw new Error('matchday must be a positive integer when provided');
+  }
+  return number;
+}
+
+function normalizeCompetition(competition = 'league') {
+  const value = String(competition || 'league').trim().toLowerCase();
+  if (!['league', 'friendly'].includes(value)) {
+    throw new Error('competition must be league or friendly');
+  }
+  return value;
+}
+
+async function approveMatch(matchId, options = {}) {
+  await ensureMatchesTable();
+  const competition = normalizeCompetition(options.competition);
+  const matchday = normalizeMatchday(options.matchday);
+  const response = await query(
+    `UPDATE matches
+     SET status = 'approved',
+         competition = $2,
+         matchday = $3,
+         notes = COALESCE($4, notes)
+     WHERE match_id = $1
+     RETURNING ${mapMatchRowColumns()}`,
+    [matchId, competition, matchday, options.notes ?? null]
+  );
+  return response.rows[0] || null;
+}
+
+async function rejectMatch(matchId, options = {}) {
+  await ensureMatchesTable();
+  const response = await query(
+    `UPDATE matches
+     SET status = 'rejected',
+         notes = COALESCE($2, notes)
+     WHERE match_id = $1
+     RETURNING ${mapMatchRowColumns()}`,
+    [matchId, options.notes ?? null]
+  );
+  return response.rows[0] || null;
+}
+
 module.exports = {
+  approveMatch,
   ensureMatchesTable,
+  getApprovedLeagueMatches,
+  getPendingMatches,
   getSavedMatches,
   insertMatch,
   normalizeMatchDate,
+  rejectMatch,
 };

--- a/public/teams.html
+++ b/public/teams.html
@@ -157,7 +157,8 @@
     }
 
     #matches,
-    #dbMatches {
+    #dbMatches,
+    #pendingMatches {
       display: grid;
       gap: 16px;
       padding: 16px;
@@ -225,6 +226,43 @@
       color: var(--muted);
       font-size: 0.82rem;
       text-align: right;
+    }
+
+
+    .approval-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      justify-content: flex-end;
+      margin-top: 12px;
+    }
+
+    .approval-actions button {
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 9px 12px;
+      background: var(--panel-strong);
+      color: var(--text);
+      cursor: pointer;
+      font-size: 0.72rem;
+      font-weight: 900;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .approval-actions button:hover { border-color: var(--success); }
+    .approval-actions button.reject:hover { border-color: var(--danger); }
+
+    .match-meta {
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-top: 8px;
+      color: var(--muted);
+      font-size: 0.72rem;
+      font-weight: 800;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
     }
 
     .empty,
@@ -1048,6 +1086,7 @@
       <button class="tab" data-tab="fixtures" type="button">Fixtures</button>
       <button class="tab" data-tab="tables" type="button">Tables</button>
       <button class="tab" data-tab="playoffs" type="button">League Playoffs</button>
+      <button class="tab" data-tab="admin" type="button">Admin</button>
     </nav>
 
     <main>
@@ -1190,6 +1229,19 @@
         <div class="league-grid" id="standings"></div>
       </section>
 
+      <section class="tab-panel" id="admin-panel" aria-label="Admin pending matches">
+        <section class="standings-card" aria-label="Pending synced matches">
+          <div class="section-heading">
+            <div>
+              <h2>Admin / Pending Matches</h2>
+              <div class="status">Approve only official league results; keep friendlies out of the table.</div>
+            </div>
+            <span class="conference-chip" id="pendingStatus">Not loaded</span>
+          </div>
+          <section id="pendingMatches" aria-label="Synced pending matches awaiting approval"></section>
+        </section>
+      </section>
+
       <section class="tab-panel" id="playoffs-panel" aria-label="UPCL League Playoffs">
         <div class="playoff-panel">
           <div class="playoff-stage-header">
@@ -1211,6 +1263,8 @@
     const syncMatchesButton = document.getElementById('syncMatches');
     const dbMatchesEl = document.getElementById('dbMatches');
     const dbStatusEl = document.getElementById('dbStatus');
+    const pendingMatchesEl = document.getElementById('pendingMatches');
+    const pendingStatusEl = document.getElementById('pendingStatus');
 
     const tabButtons = document.querySelectorAll('.tab');
     const tabPanels = document.querySelectorAll('.tab-panel');
@@ -1329,6 +1383,31 @@
             <div class="team-line"><span>${escapeHtml(match.opponent_name || 'Opponent TBD')}</span><span class="score">${scoreValue(match.opponent_score)}</span></div>
           </div>
           <div class="match-id">DB Match ID<br>${escapeHtml(match.match_id)}</div>
+        </article>
+      `;
+    }
+
+    function renderPendingMatch(match) {
+      return `
+        <article class="match-card">
+          <div>
+            <div class="result ${escapeHtml(match.result || '—')}">${escapeHtml(match.result || '—')}</div>
+            <div class="date">${escapeHtml(formatDate(match.match_date))}</div>
+          </div>
+          <div class="teams">
+            <div class="team-line"><span>${escapeHtml(match.club_name || `Club ${match.source_club_id}`)}</span><span class="score">${scoreValue(match.club_score)}</span></div>
+            <div class="team-line"><span>${escapeHtml(match.opponent_name || 'Opponent TBD')}</span><span class="score">${scoreValue(match.opponent_score)}</span></div>
+            <div class="match-meta">
+              <span>Status: ${escapeHtml(match.status || 'pending')}</span>
+              <span>Competition: ${escapeHtml(match.competition || 'friendly')}</span>
+            </div>
+            <div class="approval-actions">
+              <button type="button" data-action="approve-league" data-match-id="${escapeHtml(match.match_id)}">Approve as League Match</button>
+              <button type="button" data-action="reject" data-match-id="${escapeHtml(match.match_id)}" class="reject">Reject</button>
+              <button type="button" data-action="approve-friendly" data-match-id="${escapeHtml(match.match_id)}">Mark as Friendly</button>
+            </div>
+          </div>
+          <div class="match-id">Match ID<br>${escapeHtml(match.match_id)}</div>
         </article>
       `;
     }
@@ -1534,6 +1613,44 @@
       }
     }
 
+
+    async function loadPendingMatches() {
+      pendingStatusEl.textContent = 'Loading pending matches…';
+      try {
+        const response = await fetch('/api/pending-matches');
+        const payload = await response.json();
+        if (!response.ok) throw new Error(payload.details || payload.error || 'Request failed');
+        const matches = Array.isArray(payload.matches) ? payload.matches : [];
+        pendingStatusEl.textContent = `${matches.length} pending ${matches.length === 1 ? 'match' : 'matches'}`;
+        pendingMatchesEl.innerHTML = matches.length
+          ? matches.map(renderPendingMatch).join('')
+          : '<div class="empty">No pending synced matches need approval. Sync EA matches to import new pending results.</div>';
+      } catch (error) {
+        pendingStatusEl.textContent = 'Admin queue unavailable';
+        pendingMatchesEl.innerHTML = `<div class="error">Pending matches could not be loaded: ${escapeHtml(error.message)}</div>`;
+      }
+    }
+
+    async function updateMatchApproval(matchId, action) {
+      const isLeagueApproval = action === 'approve-league';
+      const endpointAction = action === 'reject' ? 'reject' : 'approve';
+      const body = action === 'reject'
+        ? {}
+        : { competition: isLeagueApproval ? 'league' : 'friendly' };
+
+      pendingStatusEl.textContent = 'Updating match approval…';
+      const response = await fetch(`/api/matches/${encodeURIComponent(matchId)}/${endpointAction}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      const payload = await response.json();
+      if (!response.ok) throw new Error(payload.details || payload.error || 'Approval update failed');
+      await loadPendingMatches();
+      await loadDbMatches();
+      await loadStandings();
+    }
+
     async function syncMatchesToDatabase() {
       syncMatchesButton.disabled = true;
       dbStatusEl.textContent = 'Syncing matches…';
@@ -1544,6 +1661,7 @@
         dbStatusEl.textContent = `${payload.inserted} inserted, ${payload.skipped} skipped`;
         statusEl.textContent = `Database sync complete: ${payload.totalFetched} fetched, ${payload.inserted} inserted, ${payload.skipped} skipped.`;
         await loadDbMatches();
+        await loadPendingMatches();
         await loadStandings();
       } catch (error) {
         dbStatusEl.textContent = 'Sync failed';
@@ -1560,9 +1678,23 @@
 
     refreshButton.addEventListener('click', loadMatches);
     syncMatchesButton.addEventListener('click', syncMatchesToDatabase);
+    pendingMatchesEl.addEventListener('click', async event => {
+      const button = event.target.closest('button[data-action][data-match-id]');
+      if (!button) return;
+      button.disabled = true;
+      try {
+        await updateMatchApproval(button.dataset.matchId, button.dataset.action);
+      } catch (error) {
+        pendingStatusEl.textContent = 'Approval update failed';
+        pendingMatchesEl.insertAdjacentHTML('beforebegin', `<div class="error">Match approval could not be updated: ${escapeHtml(error.message)}</div>`);
+      } finally {
+        button.disabled = false;
+      }
+    });
     renderStandingsLoading();
     loadMatches();
     loadDbMatches();
+    loadPendingMatches();
     loadStandings();
   </script>
 </body>

--- a/server.js
+++ b/server.js
@@ -155,6 +155,8 @@ function calculateStandings(savedMatches = []) {
   const formByClubId = new Map(LEAGUE_CLUBS.map(club => [club.id, []]));
 
   for (const match of savedMatches) {
+    if (match.status !== 'approved' || match.competition !== 'league') continue;
+
     const homeClub = findLeagueClub(match.source_club_id, match.club_name);
     const awayClub = findLeagueClub(null, match.opponent_name);
     const clubScore = Number(match.club_score);
@@ -279,9 +281,67 @@ app.get('/api/db-matches', async (_req, res) => {
 });
 
 
+app.get('/api/pending-matches', async (_req, res) => {
+  try {
+    const matches = await db.getPendingMatches();
+    res.json({ matches });
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to load pending matches from Postgres');
+    res.status(500).json({
+      error: 'Failed to load pending matches from Postgres',
+      details: error.message || 'Database query failed',
+      matches: [],
+    });
+  }
+});
+
+app.post('/api/matches/:matchId/approve', async (req, res) => {
+  try {
+    const match = await db.approveMatch(req.params.matchId, {
+      competition: req.body?.competition || 'league',
+      matchday: req.body?.matchday,
+      notes: req.body?.notes,
+    });
+
+    if (!match) {
+      res.status(404).json({ error: 'Match not found' });
+      return;
+    }
+
+    res.json({ match });
+  } catch (error) {
+    const status = /competition|matchday/.test(error.message || '') ? 400 : 500;
+    logger.error({ err: error, matchId: req.params.matchId }, 'Failed to approve match');
+    res.status(status).json({
+      error: 'Failed to approve match',
+      details: error.message || 'Database update failed',
+    });
+  }
+});
+
+app.post('/api/matches/:matchId/reject', async (req, res) => {
+  try {
+    const match = await db.rejectMatch(req.params.matchId, { notes: req.body?.notes });
+
+    if (!match) {
+      res.status(404).json({ error: 'Match not found' });
+      return;
+    }
+
+    res.json({ match });
+  } catch (error) {
+    logger.error({ err: error, matchId: req.params.matchId }, 'Failed to reject match');
+    res.status(500).json({
+      error: 'Failed to reject match',
+      details: error.message || 'Database update failed',
+    });
+  }
+});
+
+
 app.get('/api/standings', async (_req, res) => {
   try {
-    const matches = await db.getSavedMatches();
+    const matches = await db.getApprovedLeagueMatches();
     res.json(calculateStandings(matches));
   } catch (error) {
     logger.error({ err: error }, 'Failed to build standings from Postgres matches');

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -138,6 +138,8 @@ test('calculateStandings builds conference tables from saved league matches only
       club_score: 3,
       opponent_score: 1,
       match_date: '2026-01-01T00:00:00.000Z',
+      status: 'approved',
+      competition: 'league',
     },
     {
       id: 2,
@@ -147,6 +149,8 @@ test('calculateStandings builds conference tables from saved league matches only
       club_score: 2,
       opponent_score: 2,
       match_date: '2026-01-02T00:00:00.000Z',
+      status: 'approved',
+      competition: 'league',
     },
     {
       id: 3,
@@ -156,6 +160,8 @@ test('calculateStandings builds conference tables from saved league matches only
       club_score: 0,
       opponent_score: 1,
       match_date: '2026-01-03T00:00:00.000Z',
+      status: 'approved',
+      competition: 'league',
     },
     {
       id: 4,
@@ -165,6 +171,30 @@ test('calculateStandings builds conference tables from saved league matches only
       club_score: 9,
       opponent_score: 0,
       match_date: '2026-01-04T00:00:00.000Z',
+      status: 'approved',
+      competition: 'league',
+    },
+    {
+      id: 5,
+      source_club_id: '57985',
+      club_name: 'Bota FC',
+      opponent_name: 'Inferign United',
+      club_score: 9,
+      opponent_score: 0,
+      match_date: '2026-01-05T00:00:00.000Z',
+      status: 'pending',
+      competition: 'league',
+    },
+    {
+      id: 6,
+      source_club_id: '57985',
+      club_name: 'Bota FC',
+      opponent_name: 'Inferign United',
+      club_score: 9,
+      opponent_score: 0,
+      match_date: '2026-01-06T00:00:00.000Z',
+      status: 'approved',
+      competition: 'friendly',
     },
   ]);
 
@@ -189,7 +219,7 @@ test('calculateStandings builds conference tables from saved league matches only
 
 test('GET /api/standings returns calculated standings from saved Postgres matches', async () => {
   const db = require('../db');
-  const getStub = mock.method(db, 'getSavedMatches', async () => [
+  const getStub = mock.method(db, 'getApprovedLeagueMatches', async () => [
     {
       id: 1,
       source_club_id: '57985',
@@ -198,6 +228,8 @@ test('GET /api/standings returns calculated standings from saved Postgres matche
       club_score: 1,
       opponent_score: 0,
       match_date: '2026-01-01T00:00:00.000Z',
+      status: 'approved',
+      competition: 'league',
     },
   ]);
 
@@ -214,4 +246,63 @@ test('GET /api/standings returns calculated standings from saved Postgres matche
 
   assert.equal(getStub.mock.callCount(), 1);
   getStub.mock.restore();
+});
+
+test('GET /api/pending-matches returns synced matches awaiting approval', async () => {
+  const db = require('../db');
+  const getStub = mock.method(db, 'getPendingMatches', async () => [
+    { match_id: 'pending-1', status: 'pending', competition: 'friendly' },
+  ]);
+
+  await withServer(async port => {
+    const response = await fetch(`http://localhost:${port}/api/pending-matches`);
+    const body = await response.json();
+    assert.equal(response.status, 200);
+    assert.deepEqual(body.matches.map(match => match.match_id), ['pending-1']);
+  });
+
+  assert.equal(getStub.mock.callCount(), 1);
+  getStub.mock.restore();
+});
+
+test('POST /api/matches/:matchId/approve approves a league match with optional matchday', async () => {
+  const db = require('../db');
+  const approveStub = mock.method(db, 'approveMatch', async (matchId, options) => {
+    assert.equal(matchId, 'match-123');
+    assert.deepEqual(options, { competition: 'league', matchday: 2, notes: undefined });
+    return { match_id: matchId, status: 'approved', competition: 'league', matchday: 2 };
+  });
+
+  await withServer(async port => {
+    const response = await fetch(`http://localhost:${port}/api/matches/match-123/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ competition: 'league', matchday: 2 }),
+    });
+    const body = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(body.match.status, 'approved');
+    assert.equal(body.match.competition, 'league');
+  });
+
+  assert.equal(approveStub.mock.callCount(), 1);
+  approveStub.mock.restore();
+});
+
+test('POST /api/matches/:matchId/reject marks a match rejected', async () => {
+  const db = require('../db');
+  const rejectStub = mock.method(db, 'rejectMatch', async matchId => {
+    assert.equal(matchId, 'match-456');
+    return { match_id: matchId, status: 'rejected', competition: 'friendly' };
+  });
+
+  await withServer(async port => {
+    const response = await fetch(`http://localhost:${port}/api/matches/match-456/reject`, { method: 'POST' });
+    const body = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(body.match.status, 'rejected');
+  });
+
+  assert.equal(rejectStub.mock.callCount(), 1);
+  rejectStub.mock.restore();
 });


### PR DESCRIPTION
### Motivation
- Prevent EA-synced matches from automatically affecting standings because many are friendlies or practice games. 
- Provide an admin review flow to mark synced results as official league matches or reject/retain them as friendlies. 
- Preserve existing fixtures while making standings reflect only approved league results.

### Description
- Add match metadata columns and migration logic in `db.js`: `status` (default `pending`), `competition` (default `friendly`), `matchday`, `series_id`, and `notes`, and backfill defaults when missing. 
- Make synced inserts default to `status='pending'` and `competition='friendly'` and add DB helpers `getPendingMatches`, `getApprovedLeagueMatches`, `approveMatch`, and `rejectMatch`. 
- Update server API in `server.js`: `GET /api/pending-matches`, `POST /api/matches/:matchId/approve`, `POST /api/matches/:matchId/reject`, and change `GET /api/standings` to calculate standings from approved league matches only. 
- Add an Admin UI in `public/teams.html` showing pending synced matches with actions to Approve as League Match, Reject, or Mark as Friendly and refresh flows that update saved matches and standings. 
- Extend `test/server.test.js` with unit tests covering pending match listing, approve/reject endpoints, and standings filtering.

### Testing
- Ran the full test suite with `npm test`; all tests passed (12 passing, 0 failing). 
- Verified server and DB syntax with `node --check server.js` and `node --check db.js` with no errors. 
- Ran `git diff --check` on modified files to ensure no whitespace/errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a268602a0d8832aa8261a0f55d406ff)