### PR TITLE
Normalize team names for standings using TEAM_ALIASES

### DIFF
--- a/server.js
+++ b/server.js
@@ -90,10 +90,22 @@ function sortMatches(matches) {
   return [...matches].sort((a, b) => toNumber(b.timestamp, 0) - toNumber(a.timestamp, 0));
 }
 
+const TEAM_ALIASES = {
+  'bota fc': 'Bota FC',
+  bota: 'Bota FC',
+  'true egoistas': 'True Egoistas',
+  egoistas: 'True Egoistas',
+  'inferign united': 'Inferign United',
+  'inferign utd': 'Inferign United',
+  'versus one': 'Versus One',
+  'fc wisconson': 'FC Wisconsin',
+  'fc wisconsin': 'FC Wisconsin',
+  'fc sutton st': 'FC Sutton St',
+  'fc sutton': 'FC Sutton St',
+};
+
 const CLUB_BY_ID = new Map(LEAGUE_CLUBS.map(club => [club.id, club]));
-const CLUB_BY_NORMALIZED_NAME = new Map(
-  LEAGUE_CLUBS.flatMap(club => [club.name, ...(club.aliases || [])].map(name => [normalizeTeamName(name), club]))
-);
+const CLUB_BY_CANONICAL_NAME = new Map(LEAGUE_CLUBS.map(club => [club.name, club]));
 
 function normalizeTeamName(name) {
   return String(name || '')
@@ -104,10 +116,21 @@ function normalizeTeamName(name) {
     .replace(/\s+/g, ' ');
 }
 
+function getCanonicalTeamName(name) {
+  return TEAM_ALIASES[normalizeTeamName(name)] || null;
+}
+
 function findLeagueClub(id, name) {
   const idMatch = id === null || id === undefined ? null : CLUB_BY_ID.get(String(id));
   if (idMatch) return idMatch;
-  return CLUB_BY_NORMALIZED_NAME.get(normalizeTeamName(name)) || null;
+
+  const canonicalName = getCanonicalTeamName(name);
+  return canonicalName ? CLUB_BY_CANONICAL_NAME.get(canonicalName) || null : null;
+}
+
+function findLeagueClubByName(name) {
+  const canonicalName = getCanonicalTeamName(name);
+  return canonicalName ? CLUB_BY_CANONICAL_NAME.get(canonicalName) || null : null;
 }
 
 function createEmptyStanding(club, seed = 0) {
@@ -157,8 +180,8 @@ function calculateStandings(savedMatches = []) {
   for (const match of savedMatches) {
     if (match.status !== 'approved' || match.competition !== 'league') continue;
 
-    const homeClub = findLeagueClub(match.source_club_id, match.club_name);
-    const awayClub = findLeagueClub(null, match.opponent_name);
+    const homeClub = findLeagueClubByName(match.club_name);
+    const awayClub = findLeagueClubByName(match.opponent_name);
     const clubScore = Number(match.club_score);
     const opponentScore = Number(match.opponent_score);
 
@@ -366,5 +389,8 @@ module.exports.normalizeMatch = normalizeMatch;
 module.exports.normalizeTimestamp = normalizeTimestamp;
 module.exports.BOTA_FC = BOTA_FC;
 module.exports.LEAGUE_CLUBS = LEAGUE_CLUBS;
+module.exports.TEAM_ALIASES = TEAM_ALIASES;
 module.exports.calculateStandings = calculateStandings;
 module.exports.findLeagueClub = findLeagueClub;
+module.exports.findLeagueClubByName = findLeagueClubByName;
+module.exports.getCanonicalTeamName = getCanonicalTeamName;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -156,7 +156,7 @@ test('calculateStandings builds conference tables from saved league matches only
       id: 3,
       source_club_id: '4671025',
       club_name: 'Versus One',
-      opponent_name: 'FC Wisconsin',
+      opponent_name: 'FC Wisconson',
       club_score: 0,
       opponent_score: 1,
       match_date: '2026-01-03T00:00:00.000Z',
@@ -215,6 +215,50 @@ test('calculateStandings builds conference tables from saved league matches only
   const sutton = standings.west.find(row => row.team === 'FC Sutton St');
   assert.equal(sutton.pl, 0);
   assert.equal(sutton.pts, 0);
+});
+
+
+test('calculateStandings canonicalizes team aliases before counting league matches', () => {
+  const standings = app.calculateStandings([
+    {
+      id: 1,
+      source_club_id: '654142',
+      club_name: 'FC Wisconson',
+      opponent_name: 'fc sutton',
+      club_score: 2,
+      opponent_score: 0,
+      match_date: '2026-01-01T00:00:00.000Z',
+      status: 'approved',
+      competition: 'league',
+    },
+    {
+      id: 2,
+      source_club_id: '57985',
+      club_name: 'Non League FC',
+      opponent_name: 'Bota FC',
+      club_score: 9,
+      opponent_score: 0,
+      match_date: '2026-01-02T00:00:00.000Z',
+      status: 'approved',
+      competition: 'league',
+    },
+  ]);
+
+  assert.deepEqual(standings.west.map(row => row.team), ['FC Wisconsin', 'Versus One', 'FC Sutton St']);
+
+  const wisconsin = standings.west.find(row => row.team === 'FC Wisconsin');
+  assert.equal(wisconsin.pl, 1);
+  assert.equal(wisconsin.w, 1);
+  assert.equal(wisconsin.gf, 2);
+  assert.equal(wisconsin.pts, 3);
+
+  const sutton = standings.west.find(row => row.team === 'FC Sutton St');
+  assert.equal(sutton.pl, 1);
+  assert.equal(sutton.l, 1);
+  assert.equal(sutton.ga, 2);
+
+  const bota = standings.east.find(row => row.team === 'Bota FC');
+  assert.equal(bota.pl, 0);
 });
 
 test('GET /api/standings returns calculated standings from saved Postgres matches', async () => {


### PR DESCRIPTION
### Motivation

- EA match data may contain slight variations or misspellings of club names, causing incorrect standings counts. 
- Matches should only be counted when both sides resolve to recognized league clubs after normalization. 
- Displayed team names in standings should use the canonical league names.

### Description

- Add a `TEAM_ALIASES` map containing canonical names and common misspellings/aliases (e.g. `"fc wisconson" -> "FC Wisconsin"`).
- Introduce `getCanonicalTeamName` and `findLeagueClubByName` helpers and replace the previous normalized-name lookup with a canonical-name lookup via `CLUB_BY_CANONICAL_NAME`.
- Update `calculateStandings` to normalize both `club_name` and `opponent_name` through the aliases and only count the match when both sides resolve to league clubs, which ensures the displayed `team` uses the canonical name from `LEAGUE_CLUBS`.
- Export `TEAM_ALIASES`, `findLeagueClubByName`, and `getCanonicalTeamName` for testing/consumption.

### Testing

- Added test `calculateStandings canonicalizes team aliases before counting league matches` and adjusted an existing fixture to use a misspelled name; ran `npm test`.
- All automated tests passed: `13` tests, `0` failures (suite completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a268c664ff8832a9b8c1436f84a8282)