### PR TITLE
Add player stats foundation (DB tables, aggregation endpoint, UI)

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,5 +1,6 @@
 let pool;
 let tableReadyPromise;
+let playerStatsTablesReadyPromise;
 
 function getDatabaseUrl() {
   return process.env.DATABASE_URL;
@@ -158,6 +159,104 @@ async function getApprovedLeagueMatches() {
   return response.rows;
 }
 
+async function ensurePlayerStatsTables() {
+  if (!playerStatsTablesReadyPromise) {
+    playerStatsTablesReadyPromise = (async () => {
+      await ensureMatchesTable();
+
+      await query(`
+        CREATE TABLE IF NOT EXISTS players (
+          id serial PRIMARY KEY,
+          ea_player_id text UNIQUE,
+          player_name text NOT NULL,
+          club_id text,
+          club_name text,
+          position text,
+          avatar_url text,
+          active boolean DEFAULT true,
+          created_at timestamp DEFAULT now()
+        )
+      `);
+
+      await query(`
+        CREATE TABLE IF NOT EXISTS player_match_stats (
+          id serial PRIMARY KEY,
+          match_id text NOT NULL,
+          ea_player_id text,
+          player_name text NOT NULL,
+          club_id text,
+          club_name text,
+          goals integer DEFAULT 0,
+          assists integer DEFAULT 0,
+          passes_attempted integer DEFAULT 0,
+          passes_made integer DEFAULT 0,
+          tackles_attempted integer DEFAULT 0,
+          tackles_made integer DEFAULT 0,
+          man_of_the_match boolean DEFAULT false,
+          raw_json jsonb,
+          created_at timestamp DEFAULT now(),
+          UNIQUE(match_id, ea_player_id)
+        )
+      `);
+    })().catch(error => {
+      playerStatsTablesReadyPromise = null;
+      throw error;
+    });
+  }
+
+  return playerStatsTablesReadyPromise;
+}
+
+function normalizePercentage(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+async function getPlayerStats() {
+  await ensurePlayerStatsTables();
+  const response = await query(`
+    SELECT
+      pms.player_name,
+      MAX(pms.club_name) AS club_name,
+      COUNT(DISTINCT pms.match_id)::integer AS matches_played,
+      COALESCE(SUM(pms.goals), 0)::integer AS goals,
+      COALESCE(SUM(pms.assists), 0)::integer AS assists,
+      COALESCE(SUM(pms.passes_attempted), 0)::integer AS passes_attempted,
+      COALESCE(SUM(pms.passes_made), 0)::integer AS passes_made,
+      CASE
+        WHEN COALESCE(SUM(pms.passes_attempted), 0) = 0 THEN 0
+        ELSE ROUND((SUM(pms.passes_made)::numeric / NULLIF(SUM(pms.passes_attempted), 0)) * 100, 1)
+      END AS pass_percentage,
+      COALESCE(SUM(pms.tackles_attempted), 0)::integer AS tackles_attempted,
+      COALESCE(SUM(pms.tackles_made), 0)::integer AS tackles_made,
+      CASE
+        WHEN COALESCE(SUM(pms.tackles_attempted), 0) = 0 THEN 0
+        ELSE ROUND((SUM(pms.tackles_made)::numeric / NULLIF(SUM(pms.tackles_attempted), 0)) * 100, 1)
+      END AS tackle_percentage,
+      COUNT(*) FILTER (WHERE pms.man_of_the_match)::integer AS motm_count
+    FROM player_match_stats pms
+    INNER JOIN matches m ON m.match_id = pms.match_id
+    WHERE m.status = 'approved'
+      AND m.competition = 'league'
+    GROUP BY COALESCE(pms.ea_player_id, pms.player_name), pms.player_name
+    ORDER BY goals DESC, assists DESC, motm_count DESC, pms.player_name ASC
+  `);
+
+  return response.rows.map(row => ({
+    ...row,
+    matches_played: Number(row.matches_played) || 0,
+    goals: Number(row.goals) || 0,
+    assists: Number(row.assists) || 0,
+    passes_attempted: Number(row.passes_attempted) || 0,
+    passes_made: Number(row.passes_made) || 0,
+    pass_percentage: normalizePercentage(row.pass_percentage),
+    tackles_attempted: Number(row.tackles_attempted) || 0,
+    tackles_made: Number(row.tackles_made) || 0,
+    tackle_percentage: normalizePercentage(row.tackle_percentage),
+    motm_count: Number(row.motm_count) || 0,
+  }));
+}
+
 async function getPendingMatches() {
   await ensureMatchesTable();
   const response = await query(`
@@ -219,8 +318,10 @@ async function rejectMatch(matchId, options = {}) {
 module.exports = {
   approveMatch,
   ensureMatchesTable,
+  ensurePlayerStatsTables,
   getApprovedLeagueMatches,
   getPendingMatches,
+  getPlayerStats,
   getSavedMatches,
   insertMatch,
   normalizeMatchDate,

--- a/public/teams.html
+++ b/public/teams.html
@@ -1125,6 +1125,60 @@
     .news-category { color: var(--success); }
 
 
+
+
+    .player-stats-panel {
+      display: grid;
+      gap: 16px;
+      padding: 18px;
+    }
+
+    .player-leader-grid {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .player-leader-card {
+      display: grid;
+      gap: 8px;
+      min-height: 128px;
+      padding: 14px;
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      background: var(--surface-subtle);
+    }
+
+    .player-leader-value {
+      color: var(--text);
+      font-size: clamp(1.15rem, 2.2vw, 1.65rem);
+      font-weight: 950;
+      letter-spacing: -0.045em;
+      line-height: 1.05;
+    }
+
+    .player-leader-stat {
+      color: var(--success);
+      font-size: 0.82rem;
+      font-weight: 900;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .player-name-cell {
+      min-width: 220px;
+      text-align: left;
+      font-weight: 900;
+    }
+
+    .player-club-cell {
+      min-width: 180px;
+      text-align: left;
+      color: #cbd5e1;
+      font-weight: 800;
+    }
+
+
     .schedule-shell {
       display: grid;
       gap: 14px;
@@ -1396,7 +1450,8 @@
       .tab { padding: 10px 12px; font-size: 0.75rem; }
       .section-heading { align-items: flex-start; flex-direction: column; }
       .snapshot-grid,
-      .leader-grid { grid-template-columns: 1fr 1fr; }
+      .leader-grid,
+      .player-leader-grid { grid-template-columns: 1fr 1fr; }
       .result-row,
       .fixture-row,
       .series-card { grid-template-columns: 1fr; text-align: left; }
@@ -1473,6 +1528,7 @@
       <button class="tab" data-tab="fixtures" type="button">Fixtures</button>
       <button class="tab" data-tab="schedule" type="button">Schedule</button>
       <button class="tab" data-tab="tables" type="button">Tables</button>
+      <button class="tab" data-tab="player-stats" type="button">Player Stats</button>
       <button class="tab" data-tab="playoffs" type="button">League Playoffs</button>
       <button class="tab" data-tab="admin" type="button">Admin</button>
     </nav>
@@ -1634,6 +1690,22 @@
         <div class="league-grid" id="standings"></div>
       </section>
 
+      <section class="tab-panel" id="player-stats-panel" aria-label="UPCL player stats">
+        <section class="standings-card" aria-label="Approved league player stats">
+          <div class="section-heading">
+            <div>
+              <h2>Player Stats</h2>
+              <div class="status">Only approved league matches count toward player totals.</div>
+            </div>
+            <span class="conference-chip" id="playerStatsStatus">Not loaded</span>
+          </div>
+          <div class="player-stats-panel">
+            <div class="player-leader-grid" id="playerLeaderCards" aria-label="Player stat leaders"></div>
+            <div class="table-wrap" id="playerStatsTableWrap"></div>
+          </div>
+        </section>
+      </section>
+
       <section class="tab-panel" id="admin-panel" aria-label="Admin pending matches">
         <section class="standings-card" id="adminLogin" aria-label="Admin login">
           <div class="section-heading">
@@ -1706,6 +1778,9 @@
     const tabPanels = document.querySelectorAll('.tab-panel');
     const standingsEl = document.getElementById('standings');
     const playoffBracketEl = document.getElementById('playoffBracket');
+    const playerStatsStatusEl = document.getElementById('playerStatsStatus');
+    const playerLeaderCardsEl = document.getElementById('playerLeaderCards');
+    const playerStatsTableWrapEl = document.getElementById('playerStatsTableWrap');
 
     let standingsData = { east: [], west: [] };
     let activeScheduleFilter = 'all';
@@ -2009,6 +2084,82 @@
     }
 
 
+
+
+    function formatPercentage(value) {
+      const number = Number(value);
+      return Number.isFinite(number) ? `${number.toFixed(1)}%` : '0.0%';
+    }
+
+    function renderPlayerLeaderCard(label, player, statText) {
+      return `
+        <article class="player-leader-card">
+          <span class="leader-label">${escapeHtml(label)}</span>
+          <span class="player-leader-value">${escapeHtml(player?.player_name || '—')}</span>
+          <span class="leader-note">${escapeHtml(player?.club_name || 'No approved stats')}</span>
+          <span class="player-leader-stat">${escapeHtml(statText)}</span>
+        </article>
+      `;
+    }
+
+    function getLeader(players, selector) {
+      return [...players].sort((a, b) => selector(b) - selector(a) || String(a.player_name).localeCompare(String(b.player_name)))[0] || null;
+    }
+
+    function renderPlayerLeaders(players) {
+      const topScorer = getLeader(players, player => Number(player.goals) || 0);
+      const topAssister = getLeader(players, player => Number(player.assists) || 0);
+      const bestPasser = getLeader(players, player => Number(player.pass_percentage) || 0);
+      const bestTackler = getLeader(players, player => Number(player.tackle_percentage) || 0);
+      const mostMotm = getLeader(players, player => Number(player.motm_count) || 0);
+
+      playerLeaderCardsEl.innerHTML = [
+        renderPlayerLeaderCard('Top Scorer', topScorer, `${Number(topScorer?.goals) || 0} G`),
+        renderPlayerLeaderCard('Top Assister', topAssister, `${Number(topAssister?.assists) || 0} A`),
+        renderPlayerLeaderCard('Best Passer', bestPasser, formatPercentage(bestPasser?.pass_percentage)),
+        renderPlayerLeaderCard('Best Tackler', bestTackler, formatPercentage(bestTackler?.tackle_percentage)),
+        renderPlayerLeaderCard('Most MOTM', mostMotm, `${Number(mostMotm?.motm_count) || 0} MOTM`)
+      ].join('');
+    }
+
+    function renderPlayerStatsTable(players) {
+      if (!players.length) {
+        playerLeaderCardsEl.innerHTML = '';
+        playerStatsTableWrapEl.innerHTML = '<div class="empty">No approved player stats yet.</div>';
+        return;
+      }
+
+      renderPlayerLeaders(players);
+      playerStatsTableWrapEl.innerHTML = `
+        <table class="standings" aria-label="Full player stats table">
+          <thead>
+            <tr><th>Player</th><th>Club</th><th>MP</th><th>G</th><th>A</th><th>Pass %</th><th>Tackle %</th><th>MOTM</th></tr>
+          </thead>
+          <tbody>
+            ${players.map(player => `
+              <tr>
+                <td class="player-name-cell">${escapeHtml(player.player_name)}</td>
+                <td class="player-club-cell">${escapeHtml(player.club_name || '—')}</td>
+                <td>${Number(player.matches_played) || 0}</td>
+                <td>${Number(player.goals) || 0}</td>
+                <td>${Number(player.assists) || 0}</td>
+                <td>${formatPercentage(player.pass_percentage)}</td>
+                <td>${formatPercentage(player.tackle_percentage)}</td>
+                <td>${Number(player.motm_count) || 0}</td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
+      `;
+    }
+
+    function renderPlayerStatsLoading(message = 'Loading approved league player stats…') {
+      playerStatsStatusEl.textContent = 'Loading';
+      playerLeaderCardsEl.innerHTML = '';
+      playerStatsTableWrapEl.innerHTML = `<div class="empty">${escapeHtml(message)}</div>`;
+    }
+
+
     function getSeriesHosts(series) {
       return [
         { label: 'Game 1 host', host: series.home },
@@ -2149,6 +2300,29 @@
         renderAdminState();
         if (getAdminPassword()) loadPendingMatches();
       }
+
+      if (tabName === 'player-stats') {
+        loadPlayerStats();
+      }
+    }
+
+
+
+
+    async function loadPlayerStats() {
+      renderPlayerStatsLoading();
+      try {
+        const response = await fetch('/api/player-stats');
+        const payload = await response.json();
+        if (!response.ok) throw new Error(payload.details || payload.error || 'Request failed');
+        const players = Array.isArray(payload.players) ? payload.players : [];
+        playerStatsStatusEl.textContent = `${players.length} ${players.length === 1 ? 'player' : 'players'}`;
+        renderPlayerStatsTable(players);
+      } catch (error) {
+        playerStatsStatusEl.textContent = 'Stats unavailable';
+        playerLeaderCardsEl.innerHTML = '';
+        playerStatsTableWrapEl.innerHTML = `<div class="error">Player stats could not be loaded: ${escapeHtml(error.message)}</div>`;
+      }
     }
 
 
@@ -2243,6 +2417,7 @@
       await loadPendingMatches();
       await loadDbMatches();
       await loadStandings();
+      await loadPlayerStats();
     }
 
     async function syncMatchesToDatabase() {
@@ -2257,6 +2432,7 @@
         await loadDbMatches();
         await loadPendingMatches();
         await loadStandings();
+        await loadPlayerStats();
       } catch (error) {
         dbStatusEl.textContent = 'Sync failed';
         statusEl.textContent = 'Database sync failed.';
@@ -2315,7 +2491,9 @@
     renderStandingsLoading();
     loadMatches();
     loadDbMatches();
+    renderPlayerStatsLoading();
     loadStandings();
+    loadPlayerStats();
   </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -446,6 +446,20 @@ app.get('/api/standings', async (_req, res) => {
   }
 });
 
+app.get('/api/player-stats', async (_req, res) => {
+  try {
+    const players = await db.getPlayerStats();
+    res.json({ players });
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to load player stats from Postgres');
+    res.status(500).json({
+      error: 'Failed to load player stats',
+      details: error.message || 'Database query failed',
+      players: [],
+    });
+  }
+});
+
 if (require.main === module) {
   const port = process.env.PORT || 3000;
   app.listen(port, () => {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -297,6 +297,39 @@ test('calculateStandings canonicalizes team aliases before counting league match
   assert.equal(bota.pl, 0);
 });
 
+test('GET /api/player-stats returns approved league player totals', async () => {
+  const db = require('../db');
+  const getStub = mock.method(db, 'getPlayerStats', async () => [
+    {
+      player_name: 'Clinical Finisher',
+      club_name: 'Bota FC',
+      matches_played: 2,
+      goals: 5,
+      assists: 1,
+      passes_attempted: 20,
+      passes_made: 18,
+      pass_percentage: 90,
+      tackles_attempted: 4,
+      tackles_made: 3,
+      tackle_percentage: 75,
+      motm_count: 1,
+    },
+  ]);
+
+  await withServer(async port => {
+    const response = await fetch(`http://localhost:${port}/api/player-stats`);
+    const body = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(body.players.length, 1);
+    assert.equal(body.players[0].player_name, 'Clinical Finisher');
+    assert.equal(body.players[0].goals, 5);
+    assert.equal(body.players[0].pass_percentage, 90);
+  });
+
+  assert.equal(getStub.mock.callCount(), 1);
+  getStub.mock.restore();
+});
+
 test('GET /api/standings returns calculated standings from saved Postgres matches', async () => {
   const db = require('../db');
   const getStub = mock.method(db, 'getApprovedLeagueMatches', async () => [


### PR DESCRIPTION
### Motivation

- Provide a foundation to store and aggregate player-level statistics so leaderboards and full tables can be shown for approved league matches only.
- Keep player stats isolated from EA fetching for now and ensure only `matches.status = 'approved'` and `matches.competition = 'league'` contribute to totals.

### Description

- Database: add `players` and `player_match_stats` creation in `ensurePlayerStatsTables()` and export `getPlayerStats()` which aggregates per-player totals (goals, assists, passes, tackles, MOTM) by joining `player_match_stats` to `matches` and filtering approved league matches, computing percentages and sorting by `goals desc`, `assists desc`, `motm_count desc` (changes in `db.js`).
- Backend: add `GET /api/player-stats` which returns `{ players }` and safe error payloads (changes in `server.js`).
- Frontend: add a new `Player Stats` tab and UI shell with leader cards and a full player table, plus loading, empty, and error states, and client code to fetch `/api/player-stats` and render leader cards and the table (changes in `public/teams.html`).
- Tests: add a server test that stubs `db.getPlayerStats` and verifies `GET /api/player-stats` returns expected aggregated player records (changes in `test/server.test.js`).

### Testing

- Ran `npm test` and all automated tests passed (`17` tests, all green). 
- Performed static checks `node --check server.js` and `node --check /tmp/teams-script.js` which both succeeded.
- Attempted to run Playwright/browser tooling to capture UI screenshots but fetching Playwright from the registry failed with a `403`, so no browser-based screenshot tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a274e88d83c832a843d98d01838bafb)