### PR TITLE
Add Player Stats tab and Postgres-backed player_stats storage

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,5 +1,6 @@
 let pool;
 let tableReadyPromise;
+let playerStatsTableReadyPromise;
 
 function getDatabaseUrl() {
   return process.env.DATABASE_URL;
@@ -158,6 +159,90 @@ async function getApprovedLeagueMatches() {
   return response.rows;
 }
 
+async function ensurePlayerStatsTable() {
+  if (!playerStatsTableReadyPromise) {
+    playerStatsTableReadyPromise = (async () => {
+      await query(`
+        CREATE TABLE IF NOT EXISTS player_stats (
+          id serial PRIMARY KEY,
+          player_name text NOT NULL,
+          club_name text,
+          goals integer NOT NULL DEFAULT 0,
+          assists integer NOT NULL DEFAULT 0,
+          created_at timestamp DEFAULT now(),
+          updated_at timestamp DEFAULT now()
+        )
+      `);
+
+      await query(`
+        ALTER TABLE player_stats
+          ADD COLUMN IF NOT EXISTS club_name text,
+          ADD COLUMN IF NOT EXISTS goals integer NOT NULL DEFAULT 0,
+          ADD COLUMN IF NOT EXISTS assists integer NOT NULL DEFAULT 0,
+          ADD COLUMN IF NOT EXISTS updated_at timestamp DEFAULT now()
+      `);
+    })().catch(error => {
+      playerStatsTableReadyPromise = null;
+      throw error;
+    });
+  }
+
+  return playerStatsTableReadyPromise;
+}
+
+function normalizePlayerStatText(value, fieldName, required = false) {
+  const text = String(value || '').trim();
+  if (required && !text) throw new Error(`${fieldName} is required`);
+  return text || null;
+}
+
+function normalizePlayerStatNumber(value, fieldName) {
+  const number = Number(value ?? 0);
+  if (!Number.isInteger(number) || number < 0) {
+    throw new Error(`${fieldName} must be a non-negative integer`);
+  }
+  return number;
+}
+
+function mapPlayerStatRowColumns() {
+  return `
+    id,
+    player_name,
+    club_name,
+    goals,
+    assists,
+    created_at,
+    updated_at
+  `;
+}
+
+async function getPlayerStats() {
+  await ensurePlayerStatsTable();
+  const response = await query(`
+    SELECT ${mapPlayerStatRowColumns()}
+    FROM player_stats
+    ORDER BY goals DESC, assists DESC, player_name ASC, id ASC
+  `);
+  return response.rows;
+}
+
+async function savePlayerStat(stat) {
+  await ensurePlayerStatsTable();
+  const playerName = normalizePlayerStatText(stat.playerName ?? stat.player_name, 'playerName', true);
+  const clubName = normalizePlayerStatText(stat.clubName ?? stat.club_name, 'clubName');
+  const goals = normalizePlayerStatNumber(stat.goals, 'goals');
+  const assists = normalizePlayerStatNumber(stat.assists, 'assists');
+
+  const response = await query(
+    `INSERT INTO player_stats (player_name, club_name, goals, assists, updated_at)
+     VALUES ($1, $2, $3, $4, now())
+     RETURNING ${mapPlayerStatRowColumns()}`,
+    [playerName, clubName, goals, assists]
+  );
+
+  return response.rows[0];
+}
+
 async function getPendingMatches() {
   await ensureMatchesTable();
   const response = await query(`
@@ -219,10 +304,13 @@ async function rejectMatch(matchId, options = {}) {
 module.exports = {
   approveMatch,
   ensureMatchesTable,
+  ensurePlayerStatsTable,
   getApprovedLeagueMatches,
   getPendingMatches,
+  getPlayerStats,
   getSavedMatches,
   insertMatch,
+  savePlayerStat,
   normalizeMatchDate,
   rejectMatch,
 };

--- a/public/teams.html
+++ b/public/teams.html
@@ -1382,11 +1382,71 @@
 
     .schedule-view[hidden] { display: none; }
 
+
+    #playerStats {
+      display: grid;
+      gap: 16px;
+      padding: 16px;
+    }
+
+    .player-stat-admin {
+      border-bottom: 1px solid var(--border);
+      background: var(--panel);
+    }
+
+    .player-stat-form {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(120px, 1fr)) auto;
+      gap: 10px;
+      align-items: end;
+      padding: 16px;
+    }
+
+    .player-stat-form label {
+      display: grid;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 0.72rem;
+      font-weight: 850;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .player-stat-form input {
+      width: 100%;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 12px 14px;
+      background: var(--panel-strong);
+      color: var(--text);
+      font: inherit;
+    }
+
+    .player-stat-form button {
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 12px 18px;
+      background: var(--panel-strong);
+      color: var(--text);
+      cursor: pointer;
+      font-weight: 900;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .player-stat-form button:hover { border-color: var(--success); }
+    .player-stat-form button:disabled { cursor: wait; opacity: 0.7; }
+
+    .player-stat-admin > .status {
+      padding: 0 16px 16px;
+    }
+
     @media (max-width: 920px) {
       .league-grid { grid-template-columns: 1fr; }
       .overview-layout { grid-template-columns: 1fr; }
       .schedule-day-row { grid-template-columns: 96px minmax(0, 1fr); }
       .news-center { position: static; max-height: 520px; }
+      .player-stat-form { grid-template-columns: 1fr; }
     }
 
     @media (max-width: 720px) {
@@ -1473,6 +1533,7 @@
       <button class="tab" data-tab="fixtures" type="button">Fixtures</button>
       <button class="tab" data-tab="schedule" type="button">Schedule</button>
       <button class="tab" data-tab="tables" type="button">Tables</button>
+      <button class="tab" data-tab="player-stats" type="button">Player Stats</button>
       <button class="tab" data-tab="playoffs" type="button">League Playoffs</button>
       <button class="tab" data-tab="admin" type="button">Admin</button>
     </nav>
@@ -1634,6 +1695,17 @@
         <div class="league-grid" id="standings"></div>
       </section>
 
+
+      <section class="tab-panel" id="player-stats-panel" aria-label="UPCL player stats">
+        <section class="standings-card" aria-label="Player goals and assists leaderboard">
+          <div class="section-heading">
+            <h2>Player Stats</h2>
+            <span class="conference-chip" id="playerStatsStatus">Not loaded</span>
+          </div>
+          <section id="playerStats" aria-label="Saved Postgres player stats"></section>
+        </section>
+      </section>
+
       <section class="tab-panel" id="admin-panel" aria-label="Admin pending matches">
         <section class="standings-card" id="adminLogin" aria-label="Admin login">
           <div class="section-heading">
@@ -1664,6 +1736,34 @@
             <button class="admin-logout" id="adminLogout" type="button">Logout</button>
             <span class="conference-chip" id="pendingStatus">Not loaded</span>
           </div>
+
+          <section class="player-stat-admin" aria-label="Add player stat line">
+            <div class="section-heading">
+              <h2>Add Player Stats</h2>
+              <span class="conference-chip">Goals + assists</span>
+            </div>
+            <form id="playerStatForm" class="player-stat-form">
+              <label>
+                Player Name
+                <input id="playerNameInput" name="playerName" type="text" placeholder="Player name" required>
+              </label>
+              <label>
+                Club
+                <input id="playerClubInput" name="clubName" type="text" placeholder="Club name">
+              </label>
+              <label>
+                Goals
+                <input id="playerGoalsInput" name="goals" type="number" min="0" step="1" value="0" required>
+              </label>
+              <label>
+                Assists
+                <input id="playerAssistsInput" name="assists" type="number" min="0" step="1" value="0" required>
+              </label>
+              <button type="submit">Save Player Stats</button>
+            </form>
+            <div class="status" id="playerStatAdminStatus">Saved rows appear in the Player Stats tab.</div>
+          </section>
+
           <section id="pendingMatches" aria-label="Synced pending matches awaiting approval"></section>
         </section>
       </section>
@@ -1691,6 +1791,10 @@
     const dbStatusEl = document.getElementById('dbStatus');
     const pendingMatchesEl = document.getElementById('pendingMatches');
     const pendingStatusEl = document.getElementById('pendingStatus');
+    const playerStatsEl = document.getElementById('playerStats');
+    const playerStatsStatusEl = document.getElementById('playerStatsStatus');
+    const playerStatForm = document.getElementById('playerStatForm');
+    const playerStatAdminStatusEl = document.getElementById('playerStatAdminStatus');
     const adminLoginEl = document.getElementById('adminLogin');
     const adminDashboardEl = document.getElementById('adminDashboard');
     const adminLoginForm = document.getElementById('adminLoginForm');
@@ -1863,6 +1967,42 @@
             </div>
           </div>
           <div class="match-id">Match ID<br>${escapeHtml(match.match_id)}</div>
+        </article>
+      `;
+    }
+
+
+    function renderPlayerStatsTable(playerStats) {
+      if (!playerStats.length) {
+        return '<div class="empty">No player stats have been saved yet. Admins can add goals and assists from the Admin tab.</div>';
+      }
+
+      return `
+        <article class="standings-card">
+          <div class="table-wrap">
+            <table class="standings">
+              <thead>
+                <tr>
+                  <th>Rank</th>
+                  <th>Player</th>
+                  <th>Club</th>
+                  <th>Goals</th>
+                  <th>Assists</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${playerStats.map((stat, index) => `
+                  <tr>
+                    <td class="seed-cell">${index + 1}</td>
+                    <td class="team-cell">${escapeHtml(stat.player_name)}</td>
+                    <td>${escapeHtml(stat.club_name || 'Free Agent')}</td>
+                    <td class="points-cell">${scoreValue(stat.goals)}</td>
+                    <td class="points-cell">${scoreValue(stat.assists)}</td>
+                  </tr>
+                `).join('')}
+              </tbody>
+            </table>
+          </div>
         </article>
       `;
     }
@@ -2145,6 +2285,8 @@
       tabButtons.forEach(button => button.classList.toggle('active', button.dataset.tab === tabName));
       tabPanels.forEach(panel => panel.classList.toggle('active', panel.id === `${tabName}-panel`));
 
+      if (tabName === 'player-stats') loadPlayerStats();
+
       if (tabName === 'admin') {
         renderAdminState();
         if (getAdminPassword()) loadPendingMatches();
@@ -2186,6 +2328,55 @@
         matchesEl.innerHTML = `<div class="error">EA friendly matches could not be loaded: ${escapeHtml(error.message)}</div>`;
       } finally {
         refreshButton.disabled = false;
+      }
+    }
+
+
+    async function loadPlayerStats() {
+      playerStatsStatusEl.textContent = 'Loading player stats…';
+      try {
+        const response = await fetch('/api/player-stats');
+        const payload = await response.json();
+        if (!response.ok) throw new Error(payload.details || payload.error || 'Request failed');
+        const playerStats = Array.isArray(payload.playerStats) ? payload.playerStats : [];
+        playerStatsStatusEl.textContent = `${playerStats.length} saved ${playerStats.length === 1 ? 'player' : 'players'}`;
+        playerStatsEl.innerHTML = renderPlayerStatsTable(playerStats);
+      } catch (error) {
+        playerStatsStatusEl.textContent = 'Stats unavailable';
+        playerStatsEl.innerHTML = `<div class="error">Player stats could not be loaded: ${escapeHtml(error.message)}</div>`;
+      }
+    }
+
+    async function savePlayerStats(event) {
+      event.preventDefault();
+      const formData = new FormData(playerStatForm);
+      const payload = {
+        playerName: formData.get('playerName'),
+        clubName: formData.get('clubName'),
+        goals: formData.get('goals'),
+        assists: formData.get('assists')
+      };
+
+      const submitButton = playerStatForm.querySelector('button[type="submit"]');
+      submitButton.disabled = true;
+      playerStatAdminStatusEl.textContent = 'Saving player stats…';
+      try {
+        const response = await adminFetch('/api/player-stats', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        const body = await response.json();
+        if (!response.ok) throw new Error(body.details || body.error || 'Save failed');
+        playerStatForm.reset();
+        playerStatForm.elements.goals.value = 0;
+        playerStatForm.elements.assists.value = 0;
+        playerStatAdminStatusEl.textContent = `Saved ${body.playerStat?.player_name || 'player'} to Postgres.`;
+        await loadPlayerStats();
+      } catch (error) {
+        playerStatAdminStatusEl.textContent = `Player stats could not be saved: ${error.message}`;
+      } finally {
+        submitButton.disabled = false;
       }
     }
 
@@ -2293,6 +2484,7 @@
       renderAdminState();
       loadPendingMatches();
     });
+    playerStatForm.addEventListener('submit', savePlayerStats);
     adminLogoutButton.addEventListener('click', () => {
       localStorage.removeItem('adminPassword');
       renderAdminState();
@@ -2316,6 +2508,7 @@
     loadMatches();
     loadDbMatches();
     loadStandings();
+    loadPlayerStats();
   </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -349,6 +349,35 @@ app.get('/api/db-matches', async (_req, res) => {
 });
 
 
+
+app.get('/api/player-stats', async (_req, res) => {
+  try {
+    const playerStats = await db.getPlayerStats();
+    res.json({ playerStats });
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to load player stats from Postgres');
+    res.status(500).json({
+      error: 'Failed to load player stats from Postgres',
+      details: error.message || 'Database query failed',
+      playerStats: [],
+    });
+  }
+});
+
+app.post('/api/player-stats', adminOnly(async (req, res) => {
+  try {
+    const playerStat = await db.savePlayerStat(req.body || {});
+    res.status(201).json({ playerStat });
+  } catch (error) {
+    const status = /required|non-negative integer/.test(error.message || '') ? 400 : 500;
+    logger.error({ err: error }, 'Failed to save player stat to Postgres');
+    res.status(status).json({
+      error: 'Failed to save player stat to Postgres',
+      details: error.message || 'Database insert failed',
+    });
+  }
+}));
+
 app.get('/api/pending-matches', adminOnly(async (_req, res) => {
   try {
     const matches = await db.getPendingMatches();

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -413,3 +413,73 @@ test('POST /api/matches/:matchId/reject marks a match rejected', async () => {
   assert.equal(rejectStub.mock.callCount(), 1);
   rejectStub.mock.restore();
 });
+
+test('GET /api/player-stats returns saved player goals and assists', async () => {
+  const db = require('../db');
+  const getStub = mock.method(db, 'getPlayerStats', async () => [
+    { id: 1, player_name: 'Ace Striker', club_name: 'Bota FC', goals: 7, assists: 4 },
+    { id: 2, player_name: 'Setup Pro', club_name: 'Inferign United', goals: 2, assists: 8 },
+  ]);
+
+  await withServer(async port => {
+    const response = await fetch(`http://localhost:${port}/api/player-stats`);
+    const body = await response.json();
+    assert.equal(response.status, 200);
+    assert.deepEqual(body.playerStats.map(stat => stat.player_name), ['Ace Striker', 'Setup Pro']);
+    assert.equal(body.playerStats[0].goals, 7);
+    assert.equal(body.playerStats[1].assists, 8);
+  });
+
+  assert.equal(getStub.mock.callCount(), 1);
+  getStub.mock.restore();
+});
+
+test('POST /api/player-stats saves player goals and assists for admins', async () => {
+  const db = require('../db');
+  const saveStub = mock.method(db, 'savePlayerStat', async stat => {
+    assert.deepEqual(stat, {
+      playerName: 'Ace Striker',
+      clubName: 'Bota FC',
+      goals: 7,
+      assists: 4,
+    });
+    return { id: 1, player_name: 'Ace Striker', club_name: 'Bota FC', goals: 7, assists: 4 };
+  });
+
+  await withServer(async port => {
+    const response = await fetch(`http://localhost:${port}/api/player-stats`, {
+      method: 'POST',
+      headers: adminHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ playerName: 'Ace Striker', clubName: 'Bota FC', goals: 7, assists: 4 }),
+    });
+    const body = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(body.playerStat.player_name, 'Ace Striker');
+    assert.equal(body.playerStat.goals, 7);
+    assert.equal(body.playerStat.assists, 4);
+  });
+
+  assert.equal(saveStub.mock.callCount(), 1);
+  saveStub.mock.restore();
+});
+
+test('POST /api/player-stats rejects missing admin password', async () => {
+  const db = require('../db');
+  const saveStub = mock.method(db, 'savePlayerStat', async () => {
+    throw new Error('admin auth should run before saving player stats');
+  });
+
+  await withServer(async port => {
+    const response = await fetch(`http://localhost:${port}/api/player-stats`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ playerName: 'Ace Striker', goals: 1, assists: 1 }),
+    });
+    const body = await response.json();
+    assert.equal(response.status, 401);
+    assert.deepEqual(body, { error: 'Unauthorized' });
+  });
+
+  assert.equal(saveStub.mock.callCount(), 0);
+  saveStub.mock.restore();
+});


### PR DESCRIPTION
### Motivation
- Provide a simple, admin-driven leaderboard for individual player goals and assists that persists to Postgres so leaders can be shown in the UI.
- Expose a public read endpoint and an admin-protected write endpoint so client UI can load and admins can record stat lines.

### Description
- Add `player_stats` table management and helpers in `db.js` with `ensurePlayerStatsTable`, `getPlayerStats`, `savePlayerStat`, and validation for required player name and non-negative integers for goals/assists.
- Add server routes `GET /api/player-stats` (public) and `POST /api/player-stats` (admin-only) in `server.js` to read and save player stat rows and return appropriate error codes on validation failure.
- Add a `Player Stats` tab and client UI in `public/teams.html` that shows a ranked leaderboard and includes an admin form to submit `playerName`, `clubName`, `goals`, and `assists`, plus client-side `loadPlayerStats`/`savePlayerStats` integration.
- Add tests in `test/server.test.js` covering `GET /api/player-stats`, `POST /api/player-stats` with admin auth, and rejection when admin auth is missing.

### Testing
- Ran the automated test suite with `npm test`, which passed: 19 tests, 0 failures (including the new player-stats tests).
- Added unit tests that stub `db.getPlayerStats` and `db.savePlayerStat` to verify read/write API behavior and admin authorization handling, and they succeeded under `npm test`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27516ff224832a8591efb4665f42a2)