### PR TITLE
Add player stats foundation

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,5 +1,6 @@
 let pool;
 let tableReadyPromise;
+let playerStatsReadyPromise;
 
 function getDatabaseUrl() {
   return process.env.DATABASE_URL;
@@ -73,6 +74,86 @@ async function ensureMatchesTable() {
   }
 
   return tableReadyPromise;
+}
+
+async function ensurePlayerStatsTables() {
+  if (!playerStatsReadyPromise) {
+    playerStatsReadyPromise = (async () => {
+      await ensureMatchesTable();
+
+      await query(`
+        CREATE TABLE IF NOT EXISTS players (
+          id serial PRIMARY KEY,
+          ea_player_id text UNIQUE,
+          player_name text NOT NULL,
+          club_id text,
+          club_name text,
+          position text,
+          avatar_url text,
+          active boolean DEFAULT true,
+          created_at timestamp DEFAULT now()
+        )
+      `);
+
+      await query(`
+        CREATE TABLE IF NOT EXISTS player_match_stats (
+          id serial PRIMARY KEY,
+          match_id text NOT NULL,
+          ea_player_id text,
+          player_name text NOT NULL,
+          club_id text,
+          club_name text,
+          goals integer DEFAULT 0,
+          assists integer DEFAULT 0,
+          passes_attempted integer DEFAULT 0,
+          passes_made integer DEFAULT 0,
+          tackles_attempted integer DEFAULT 0,
+          tackles_made integer DEFAULT 0,
+          man_of_the_match boolean DEFAULT false,
+          raw_json jsonb,
+          created_at timestamp DEFAULT now(),
+          UNIQUE(match_id, ea_player_id)
+        )
+      `);
+    })().catch(error => {
+      playerStatsReadyPromise = null;
+      throw error;
+    });
+  }
+
+  return playerStatsReadyPromise;
+}
+
+async function getPlayerStats() {
+  await ensurePlayerStatsTables();
+  const response = await query(`
+    SELECT
+      pms.player_name,
+      COALESCE(MAX(NULLIF(pms.club_name, '')), '') AS club_name,
+      COUNT(DISTINCT pms.match_id)::integer AS matches_played,
+      COALESCE(SUM(pms.goals), 0)::integer AS goals,
+      COALESCE(SUM(pms.assists), 0)::integer AS assists,
+      COALESCE(SUM(pms.passes_attempted), 0)::integer AS passes_attempted,
+      COALESCE(SUM(pms.passes_made), 0)::integer AS passes_made,
+      CASE
+        WHEN COALESCE(SUM(pms.passes_attempted), 0) = 0 THEN 0
+        ELSE ROUND((SUM(pms.passes_made)::numeric / NULLIF(SUM(pms.passes_attempted), 0)) * 100, 1)
+      END::float AS pass_percentage,
+      COALESCE(SUM(pms.tackles_attempted), 0)::integer AS tackles_attempted,
+      COALESCE(SUM(pms.tackles_made), 0)::integer AS tackles_made,
+      CASE
+        WHEN COALESCE(SUM(pms.tackles_attempted), 0) = 0 THEN 0
+        ELSE ROUND((SUM(pms.tackles_made)::numeric / NULLIF(SUM(pms.tackles_attempted), 0)) * 100, 1)
+      END::float AS tackle_percentage,
+      COALESCE(SUM(CASE WHEN pms.man_of_the_match THEN 1 ELSE 0 END), 0)::integer AS motm_count
+    FROM player_match_stats pms
+    INNER JOIN matches m ON m.match_id = pms.match_id
+    WHERE m.status = 'approved'
+      AND m.competition = 'league'
+    GROUP BY COALESCE(pms.ea_player_id, pms.player_name), pms.player_name
+    ORDER BY goals DESC, assists DESC, motm_count DESC, pms.player_name ASC
+  `);
+  return response.rows;
 }
 
 function normalizeMatchDate(timestamp) {
@@ -219,8 +300,10 @@ async function rejectMatch(matchId, options = {}) {
 module.exports = {
   approveMatch,
   ensureMatchesTable,
+  ensurePlayerStatsTables,
   getApprovedLeagueMatches,
   getPendingMatches,
+  getPlayerStats,
   getSavedMatches,
   insertMatch,
   normalizeMatchDate,

--- a/public/teams.html
+++ b/public/teams.html
@@ -112,6 +112,7 @@
     .empty,
     .error,
     .standings-card,
+    .player-stats-card,
     .playoff-panel {
       border: 1px solid var(--border);
       border-radius: 22px;
@@ -1382,10 +1383,45 @@
 
     .schedule-view[hidden] { display: none; }
 
+
+    .player-stats-shell {
+      display: grid;
+      gap: 16px;
+    }
+
+    .player-leader-grid {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      padding: 16px;
+    }
+
+    .player-stats-card {
+      overflow: hidden;
+    }
+
+    .player-stats-table td.player-cell,
+    .player-stats-table td.club-cell-text {
+      min-width: 180px;
+      text-align: left;
+      font-weight: 900;
+    }
+
+    .player-stats-table td.club-cell-text {
+      color: #cbd5e1;
+      font-weight: 800;
+    }
+
+    .percentage-cell {
+      color: #eef4fa;
+      font-weight: 900;
+    }
+
     @media (max-width: 920px) {
       .league-grid { grid-template-columns: 1fr; }
       .overview-layout { grid-template-columns: 1fr; }
       .schedule-day-row { grid-template-columns: 96px minmax(0, 1fr); }
+      .player-leader-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       .news-center { position: static; max-height: 520px; }
     }
 
@@ -1396,7 +1432,8 @@
       .tab { padding: 10px 12px; font-size: 0.75rem; }
       .section-heading { align-items: flex-start; flex-direction: column; }
       .snapshot-grid,
-      .leader-grid { grid-template-columns: 1fr 1fr; }
+      .leader-grid,
+      .player-leader-grid { grid-template-columns: 1fr 1fr; }
       .result-row,
       .fixture-row,
       .series-card { grid-template-columns: 1fr; text-align: left; }
@@ -1473,6 +1510,7 @@
       <button class="tab" data-tab="fixtures" type="button">Fixtures</button>
       <button class="tab" data-tab="schedule" type="button">Schedule</button>
       <button class="tab" data-tab="tables" type="button">Tables</button>
+      <button class="tab" data-tab="player-stats" type="button">Player Stats</button>
       <button class="tab" data-tab="playoffs" type="button">League Playoffs</button>
       <button class="tab" data-tab="admin" type="button">Admin</button>
     </nav>
@@ -1634,6 +1672,29 @@
         <div class="league-grid" id="standings"></div>
       </section>
 
+      <section class="tab-panel" id="player-stats-panel" aria-label="UPCL player stats">
+        <div class="player-stats-shell">
+          <section class="player-stats-card" aria-labelledby="playerStatsLeadersTitle">
+            <div class="section-heading">
+              <div>
+                <h2 id="playerStatsLeadersTitle">Player Stat Leaders</h2>
+                <div class="status">Approved league matches only.</div>
+              </div>
+              <span class="conference-chip" id="playerStatsStatus">Not loaded</span>
+            </div>
+            <div class="player-leader-grid" id="playerStatsLeaders"></div>
+          </section>
+
+          <section class="player-stats-card" aria-labelledby="playerStatsTableTitle">
+            <div class="section-heading">
+              <h2 id="playerStatsTableTitle">Full Player Table</h2>
+              <span class="conference-chip">League totals</span>
+            </div>
+            <div id="playerStatsTable"></div>
+          </section>
+        </div>
+      </section>
+
       <section class="tab-panel" id="admin-panel" aria-label="Admin pending matches">
         <section class="standings-card" id="adminLogin" aria-label="Admin login">
           <div class="section-heading">
@@ -1705,9 +1766,13 @@
     const tabButtons = document.querySelectorAll('.tab');
     const tabPanels = document.querySelectorAll('.tab-panel');
     const standingsEl = document.getElementById('standings');
+    const playerStatsStatusEl = document.getElementById('playerStatsStatus');
+    const playerStatsLeadersEl = document.getElementById('playerStatsLeaders');
+    const playerStatsTableEl = document.getElementById('playerStatsTable');
     const playoffBracketEl = document.getElementById('playoffBracket');
 
     let standingsData = { east: [], west: [] };
+    let playerStatsData = [];
     let activeScheduleFilter = 'all';
 
 
@@ -2009,6 +2074,78 @@
     }
 
 
+    function formatPercentage(value) {
+      const number = Number(value);
+      if (!Number.isFinite(number)) return '0%';
+      return `${number.toFixed(number % 1 === 0 ? 0 : 1)}%`;
+    }
+
+    function getLeader(players, metric) {
+      return players
+        .filter(player => Number(player[metric]) > 0)
+        .sort((a, b) => Number(b[metric]) - Number(a[metric]) || String(a.player_name).localeCompare(String(b.player_name)))[0] || null;
+    }
+
+    function renderPlayerLeaderCard(label, player, valueFormatter) {
+      const value = player ? valueFormatter(player) : '—';
+      const note = player ? `${player.player_name}${player.club_name ? ` · ${player.club_name}` : ''}` : 'No approved player stats yet.';
+      return `<div class="leader-card"><span class="leader-label">${escapeHtml(label)}</span><span class="leader-value">${escapeHtml(value)}</span><span class="leader-note">${escapeHtml(note)}</span></div>`;
+    }
+
+    function renderPlayerStatsLeaders(players) {
+      const leaders = [
+        ['Top Scorer', getLeader(players, 'goals'), player => String(player.goals)],
+        ['Top Assister', getLeader(players, 'assists'), player => String(player.assists)],
+        ['Best Passer', getLeader(players, 'pass_percentage'), player => formatPercentage(player.pass_percentage)],
+        ['Best Tackler', getLeader(players, 'tackle_percentage'), player => formatPercentage(player.tackle_percentage)],
+        ['Most MOTM', getLeader(players, 'motm_count'), player => String(player.motm_count)]
+      ];
+      playerStatsLeadersEl.innerHTML = leaders.map(([label, player, formatter]) => renderPlayerLeaderCard(label, player, formatter)).join('');
+    }
+
+    function renderPlayerStatsTable(players) {
+      if (!players.length) {
+        playerStatsTableEl.innerHTML = '<div class="empty">No approved player stats yet.</div>';
+        return;
+      }
+
+      playerStatsTableEl.innerHTML = `
+        <div class="table-wrap">
+          <table class="standings player-stats-table">
+            <thead>
+              <tr><th>Player</th><th>Club</th><th>MP</th><th>G</th><th>A</th><th>Pass %</th><th>Tackle %</th><th>MOTM</th></tr>
+            </thead>
+            <tbody>
+              ${players.map(player => `
+                <tr>
+                  <td class="player-cell">${escapeHtml(player.player_name)}</td>
+                  <td class="club-cell-text">${escapeHtml(player.club_name || '—')}</td>
+                  <td>${Number(player.matches_played) || 0}</td>
+                  <td>${Number(player.goals) || 0}</td>
+                  <td>${Number(player.assists) || 0}</td>
+                  <td class="percentage-cell">${escapeHtml(formatPercentage(player.pass_percentage))}</td>
+                  <td class="percentage-cell">${escapeHtml(formatPercentage(player.tackle_percentage))}</td>
+                  <td>${Number(player.motm_count) || 0}</td>
+                </tr>
+              `).join('')}
+            </tbody>
+          </table>
+        </div>
+      `;
+    }
+
+    function renderPlayerStats(players) {
+      renderPlayerStatsLeaders(players);
+      renderPlayerStatsTable(players);
+    }
+
+    function renderPlayerStatsLoading(message = 'Loading approved league player stats…') {
+      playerStatsStatusEl.textContent = 'Loading';
+      playerStatsLeadersEl.innerHTML = '';
+      playerStatsTableEl.innerHTML = `<div class="empty">${escapeHtml(message)}</div>`;
+    }
+
+
     function getSeriesHosts(series) {
       return [
         { label: 'Game 1 host', host: series.home },
@@ -2149,6 +2286,10 @@
         renderAdminState();
         if (getAdminPassword()) loadPendingMatches();
       }
+
+      if (tabName === 'player-stats' && !playerStatsData.length) {
+        loadPlayerStats();
+      }
     }
 
 
@@ -2168,6 +2309,23 @@
         playoffBracketEl.innerHTML = renderPlayoffBracket();
       }
     }
+
+    async function loadPlayerStats() {
+      renderPlayerStatsLoading();
+      try {
+        const response = await fetch('/api/player-stats');
+        const payload = await response.json();
+        if (!response.ok) throw new Error(payload.details || payload.error || 'Request failed');
+        playerStatsData = Array.isArray(payload.players) ? payload.players : [];
+        playerStatsStatusEl.textContent = `${playerStatsData.length} ${playerStatsData.length === 1 ? 'player' : 'players'}`;
+        renderPlayerStats(playerStatsData);
+      } catch (error) {
+        playerStatsStatusEl.textContent = 'Unavailable';
+        playerStatsLeadersEl.innerHTML = '';
+        playerStatsTableEl.innerHTML = `<div class="error">Player stats could not be loaded: ${escapeHtml(error.message)}</div>`;
+      }
+    }
+
 
     async function loadMatches() {
       refreshButton.disabled = true;
@@ -2243,6 +2401,7 @@
       await loadPendingMatches();
       await loadDbMatches();
       await loadStandings();
+      await loadPlayerStats();
     }
 
     async function syncMatchesToDatabase() {
@@ -2257,6 +2416,7 @@
         await loadDbMatches();
         await loadPendingMatches();
         await loadStandings();
+        await loadPlayerStats();
       } catch (error) {
         dbStatusEl.textContent = 'Sync failed';
         statusEl.textContent = 'Database sync failed.';
@@ -2313,9 +2473,11 @@
     renderScheduleWeekView();
     renderAdminState();
     renderStandingsLoading();
+    renderPlayerStatsLoading();
     loadMatches();
     loadDbMatches();
     loadStandings();
+    loadPlayerStats();
   </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -431,6 +431,21 @@ app.post('/api/matches/:matchId/friendly', adminOnly(async (req, res) => {
 }));
 
 
+
+app.get('/api/player-stats', async (_req, res) => {
+  try {
+    const players = await db.getPlayerStats();
+    res.json({ players });
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to load approved league player stats');
+    res.status(500).json({
+      error: 'Failed to load player stats',
+      details: error.message || 'Database query failed',
+      players: [],
+    });
+  }
+});
+
 app.get('/api/standings', async (_req, res) => {
   try {
     const matches = await db.getApprovedLeagueMatches();

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -413,3 +413,36 @@ test('POST /api/matches/:matchId/reject marks a match rejected', async () => {
   assert.equal(rejectStub.mock.callCount(), 1);
   rejectStub.mock.restore();
 });
+
+test('GET /api/player-stats returns approved league player stat totals', async () => {
+  const db = require('../db');
+  const getStub = mock.method(db, 'getPlayerStats', async () => [
+    {
+      player_name: 'Striker One',
+      club_name: 'Bota FC',
+      matches_played: 2,
+      goals: 4,
+      assists: 1,
+      passes_attempted: 20,
+      passes_made: 18,
+      pass_percentage: 90,
+      tackles_attempted: 5,
+      tackles_made: 3,
+      tackle_percentage: 60,
+      motm_count: 1,
+    },
+  ]);
+
+  await withServer(async port => {
+    const response = await fetch(`http://localhost:${port}/api/player-stats`);
+    const body = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(body.players.length, 1);
+    assert.equal(body.players[0].player_name, 'Striker One');
+    assert.equal(body.players[0].goals, 4);
+    assert.equal(body.players[0].pass_percentage, 90);
+  });
+
+  assert.equal(getStub.mock.callCount(), 1);
+  getStub.mock.restore();
+});


### PR DESCRIPTION
### Motivation
- Provide a database foundation and UI to surface per-player statistics aggregated from approved league matches only. 
- Prepare a safe server-side aggregation so UI can display leaders and a full player table without calling EA for player details yet.

### Description
- Add `players` and `player_match_stats` table creation in `db.js` via `ensurePlayerStatsTables()` and expose an aggregation helper `getPlayerStats()` that joins `player_match_stats` to `matches` and computes totals and percentages (passes/tackles) and `motm_count` sorted by goals, assists, and MOTM.
- Add a new route `GET /api/player-stats` in `server.js` that returns `{ players }` and handles DB errors with a safe empty array payload.
- Add a `Player Stats` tab in `public/teams.html` with leader cards (Top Scorer, Top Assister, Best Passer, Best Tackler, Most MOTM), a full player table (MP, G, A, Pass %, Tackle %, MOTM), loading and empty states, and frontend logic (`loadPlayerStats`, render helpers, and wiring) that fetches `/api/player-stats` and updates UI without introducing EA API calls for player profiles.
- Add a test in `test/server.test.js` that stubs `db.getPlayerStats` and verifies the API returns the expected aggregated payload.

### Testing
- Ran static checks and executed the frontend script by validating `server.js` and `db.js` with `node -c`, evaluating the page script, and running the test suite via `npm test` as: `node -c server.js && node -c db.js && node -e "const fs=require('fs'); const html=fs.readFileSync('public/teams.html','utf8'); const script=html.match(/<script>([\s\S]*)<\/script>/)[1]; new Function(script);" && npm test`.
- All automated tests passed (`17` tests passing, `0` failures) and the new `GET /api/player-stats` test succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a276a8639d8832aa70519821e204ee7)