### PR TITLE
Add admin reset for approved matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ These routes require the `x-admin-password` header:
 - `POST /api/matches/:matchId/approve`
 - `POST /api/matches/:matchId/reject`
 - `POST /api/matches/:matchId/friendly`
+- `POST /api/admin/reset-approved-matches`
 
 ## Frontend
 

--- a/db.js
+++ b/db.js
@@ -284,6 +284,20 @@ async function approveMatch(matchId, options = {}) {
   return response.rows[0] || null;
 }
 
+
+async function resetApprovedMatches() {
+  await ensureMatchesTable();
+  const response = await query(`
+    UPDATE matches
+    SET status = 'pending',
+        competition = 'friendly',
+        matchday = NULL,
+        series_id = NULL
+    WHERE status = 'approved'
+  `);
+  return response.rowCount || 0;
+}
+
 async function rejectMatch(matchId, options = {}) {
   await ensureMatchesTable();
   const response = await query(
@@ -307,5 +321,6 @@ module.exports = {
   getSavedMatches,
   insertMatch,
   normalizeMatchDate,
+  resetApprovedMatches,
   rejectMatch,
 };

--- a/public/teams.html
+++ b/public/teams.html
@@ -197,7 +197,8 @@
     }
 
     .admin-login button,
-    .admin-logout {
+    .admin-logout,
+    .admin-reset {
       border: 1px solid var(--border);
       border-radius: 999px;
       padding: 12px 18px;
@@ -211,6 +212,8 @@
 
     .admin-logout:hover,
     .admin-login button:hover { border-color: var(--success); }
+    .admin-reset:hover { border-color: var(--danger); }
+    .admin-reset:disabled { cursor: wait; opacity: 0.7; }
 
     .admin-dashboard[hidden],
     .admin-login[hidden] { display: none; }
@@ -1722,6 +1725,7 @@
               <h2>Admin / Pending Matches</h2>
               <div class="status">Approve only official league results; keep friendlies out of the table.</div>
             </div>
+            <button class="admin-reset" id="resetApprovedMatches" type="button">Reset Approved Matches</button>
             <button class="admin-logout" id="adminLogout" type="button">Logout</button>
             <span class="conference-chip" id="pendingStatus">Not loaded</span>
           </div>
@@ -1758,6 +1762,7 @@
     const adminPasswordInput = document.getElementById('adminPasswordInput');
     const adminLoginErrorEl = document.getElementById('adminLoginError');
     const adminLogoutButton = document.getElementById('adminLogout');
+    const resetApprovedMatchesButton = document.getElementById('resetApprovedMatches');
     const scheduleViewButtons = document.querySelectorAll('.schedule-view-button');
     const scheduleFilterButtons = document.querySelectorAll('.schedule-filter-pill');
     const scheduleWeekViewEl = document.getElementById('scheduleWeekView');
@@ -2404,6 +2409,28 @@
       await loadPlayerStats();
     }
 
+    async function resetApprovedMatches() {
+      const confirmed = window.confirm('This will remove approved matches from standings and move them back to pending. Continue?');
+      if (!confirmed) return;
+
+      resetApprovedMatchesButton.disabled = true;
+      pendingStatusEl.textContent = 'Resetting approved matches…';
+      try {
+        const response = await adminFetch('/api/admin/reset-approved-matches', { method: 'POST' });
+        const payload = await response.json();
+        if (!response.ok) throw new Error(payload.details || payload.error || 'Reset failed');
+        pendingStatusEl.textContent = `${payload.reset} approved ${payload.reset === 1 ? 'match' : 'matches'} reset`;
+        await loadPendingMatches();
+        await loadStandings();
+        await loadPlayerStats();
+      } catch (error) {
+        pendingStatusEl.textContent = 'Reset failed';
+        pendingMatchesEl.insertAdjacentHTML('beforebegin', `<div class="error">Approved matches could not be reset: ${escapeHtml(error.message)}</div>`);
+      } finally {
+        resetApprovedMatchesButton.disabled = false;
+      }
+    }
+
     async function syncMatchesToDatabase() {
       syncMatchesButton.disabled = true;
       dbStatusEl.textContent = 'Syncing matches…';
@@ -2444,6 +2471,7 @@
 
     refreshButton.addEventListener('click', loadMatches);
     syncMatchesButton.addEventListener('click', syncMatchesToDatabase);
+    resetApprovedMatchesButton.addEventListener('click', resetApprovedMatches);
     adminLoginForm.addEventListener('submit', event => {
       event.preventDefault();
       const password = adminPasswordInput.value.trim();

--- a/server.js
+++ b/server.js
@@ -349,6 +349,20 @@ app.get('/api/db-matches', async (_req, res) => {
 });
 
 
+
+app.post('/api/admin/reset-approved-matches', adminOnly(async (_req, res) => {
+  try {
+    const reset = await db.resetApprovedMatches();
+    res.json({ reset });
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to reset approved matches');
+    res.status(500).json({
+      error: 'Failed to reset approved matches',
+      details: error.message || 'Database update failed',
+    });
+  }
+}));
+
 app.get('/api/pending-matches', adminOnly(async (_req, res) => {
   try {
     const matches = await db.getPendingMatches();

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -137,6 +137,41 @@ test('POST /api/sync-matches rejects missing admin password', async () => {
   ensureStub.mock.restore();
 });
 
+test('POST /api/admin/reset-approved-matches resets approved matches with admin auth', async () => {
+  const db = require('../db');
+  const resetStub = mock.method(db, 'resetApprovedMatches', async () => 4);
+
+  await withServer(async port => {
+    const response = await fetch(`http://localhost:${port}/api/admin/reset-approved-matches`, {
+      method: 'POST',
+      headers: adminHeaders(),
+    });
+    const body = await response.json();
+    assert.equal(response.status, 200);
+    assert.deepEqual(body, { reset: 4 });
+  });
+
+  assert.equal(resetStub.mock.callCount(), 1);
+  resetStub.mock.restore();
+});
+
+test('POST /api/admin/reset-approved-matches rejects missing admin password', async () => {
+  const db = require('../db');
+  const resetStub = mock.method(db, 'resetApprovedMatches', async () => {
+    throw new Error('admin auth should run before reset');
+  });
+
+  await withServer(async port => {
+    const response = await fetch(`http://localhost:${port}/api/admin/reset-approved-matches`, { method: 'POST' });
+    const body = await response.json();
+    assert.equal(response.status, 401);
+    assert.deepEqual(body, { error: 'Unauthorized' });
+  });
+
+  assert.equal(resetStub.mock.callCount(), 0);
+  resetStub.mock.restore();
+});
+
 test('GET /api/news returns public news without admin password', async () => {
   await withServer(async port => {
     const response = await fetch(`http://localhost:${port}/api/news`);


### PR DESCRIPTION
### Motivation
- Provide an admin tool to restart the approval process for matches without deleting rows or removing raw JSON or history.
- Ensure approved matches can be moved back to the pending queue and excluded from standings/league aggregates.

### Description
- Add `resetApprovedMatches()` in `db.js` which updates rows where `status = 'approved'` to `status = 'pending'`, sets `competition = 'friendly'`, and clears `matchday` and `series_id`, returning the affected row count.
- Add protected backend route `POST /api/admin/reset-approved-matches` in `server.js` that requires admin auth and returns `{ reset: number }`.
- Add a frontend Admin button `Reset Approved Matches` in `public/teams.html` with a confirmation prompt and client flow that calls the new admin endpoint and then refreshes pending matches, standings, and player stats on success.
- Document the new admin route in `README.md` and add tests in `test/server.test.js` covering successful reset and rejection when admin auth is missing.

### Testing
- Ran the test suite with `npm test`, all tests passed (`19` tests, `0` failures).
- Added automated tests for `POST /api/admin/reset-approved-matches` for both authorized and unauthorized cases and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a276ccea77c832a8e7ede0b88659476)