### PR TITLE
Handle nested EA match payloads and deduplicate matches

### DIFF
--- a/services/eaApi.js
+++ b/services/eaApi.js
@@ -24,11 +24,59 @@ function normalizeClubId(clubId) {
   return id;
 }
 
+function isMatchPayload(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value) && (
+    value.matchId !== undefined ||
+    value.matchid !== undefined ||
+    value.id !== undefined ||
+    value.clubs !== undefined ||
+    value.players !== undefined
+  ));
+}
+
+function getMatchPayloadId(match) {
+  const id = match?.matchId ?? match?.matchid ?? match?.id;
+  return id === undefined || id === null || id === '' ? null : String(id);
+}
+
+function appendUniqueMatch(matches, seenIds, match) {
+  const id = getMatchPayloadId(match);
+  if (id) {
+    if (seenIds.has(id)) return;
+    seenIds.add(id);
+  }
+  matches.push(match);
+}
+
+function collectMatchesPayload(value, clubId, matches, seenIds) {
+  if (!value) return;
+
+  if (Array.isArray(value)) {
+    for (const item of value) collectMatchesPayload(item, clubId, matches, seenIds);
+    return;
+  }
+
+  if (isMatchPayload(value)) {
+    appendUniqueMatch(matches, seenIds, value);
+    return;
+  }
+
+  if (typeof value !== 'object') return;
+
+  if (value[clubId] !== undefined) {
+    collectMatchesPayload(value[clubId], clubId, matches, seenIds);
+    return;
+  }
+
+  if (value.matches !== undefined) {
+    collectMatchesPayload(value.matches, clubId, matches, seenIds);
+  }
+}
+
 function readMatchesPayload(body, clubId) {
-  if (Array.isArray(body)) return body;
-  if (Array.isArray(body?.matches)) return body.matches;
-  if (Array.isArray(body?.[clubId])) return body[clubId];
-  return [];
+  const matches = [];
+  collectMatchesPayload(body, String(clubId), matches, new Set());
+  return matches;
 }
 
 async function eaFetchJson(url, { retries = 2 } = {}) {

--- a/test/eaApi.test.js
+++ b/test/eaApi.test.js
@@ -19,3 +19,13 @@ test('readMatchesPayload accepts EA array, keyed, and matches payloads', () => {
   assert.deepEqual(readMatchesPayload({ matches: [match] }, '57985'), [match]);
   assert.deepEqual(readMatchesPayload({}, '57985'), []);
 });
+
+
+test('readMatchesPayload flattens nested duplicate EA match arrays', () => {
+  const first = { matchId: '716874327810264', clubs: { 2924517: { goals: '0' }, 72600: { goals: '3' } } };
+  const second = { matchId: '716774422480032', clubs: { 2924517: { goals: '2' }, 3485690: { goals: '3' } } };
+
+  assert.deepEqual(readMatchesPayload([[first, second], [first]], '2924517'), [first, second]);
+  assert.deepEqual(readMatchesPayload({ 2924517: [[first], [second, first]] }, '2924517'), [first, second]);
+  assert.deepEqual(readMatchesPayload({ matches: [[first], [second]] }, '2924517'), [first, second]);
+});

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -38,6 +38,46 @@ test('normalizes Bota FC friendly matches', () => {
   assert.equal(match.result, 'W');
 });
 
+test('normalizes supplied Club Alucin DNF match using club score instead of player aggregates', () => {
+  const match = app.normalizeMatch({
+    matchId: '716874327810264',
+    timestamp: 1_780_962_508,
+    clubs: {
+      72600: {
+        goals: '3',
+        score: '3',
+        winnerByDnf: '1',
+        details: { name: 'apolllo fc' },
+      },
+      2924517: {
+        goals: '0',
+        score: '0',
+        winnerByDnf: '0',
+        details: { name: 'Club Alucin' },
+      },
+    },
+    players: {
+      72600: {
+        1742721482: { playername: 'Aztek_Warrior714', goals: '3' },
+        1004825985059: { playername: 'RelatableSenpai', goals: '1' },
+      },
+      2924517: {
+        1009074278715: { playername: 'Carlosfrmzz8', goals: '1' },
+      },
+    },
+    aggregate: {
+      72600: { goals: 4 },
+      2924517: { goals: 1 },
+    },
+  }, 0, { id: '2924517', name: 'Club Alucin' });
+
+  assert.equal(match.id, '716874327810264');
+  assert.equal(match.team.name, 'Club Alucin');
+  assert.equal(match.opponent.name, 'apolllo fc');
+  assert.deepEqual(match.score, { for: 0, against: 3 });
+  assert.equal(match.result, 'L');
+});
+
 test('GET /api/matches returns friendly matches for Bota FC', async () => {
   const fetchStub = mock.method(eaApi, 'fetchFriendlyMatches', async clubId => {
     assert.equal(clubId, '57985');


### PR DESCRIPTION
### Motivation
- The EA match responses can arrive as nested arrays/objects (raw arrays, keyed by club id, or wrapped in a `matches` property) and may include duplicated entries, which breaks normalization and sync logic.
- Some EA payloads use official club-level fields (`score`, `winnerByDnf`) that must be respected instead of relying on player/aggregate totals when normalizing results.

### Description
- Replace the simplistic `readMatchesPayload` with a recursive collector that flattens nested arrays/objects and extracts real match payloads from raw arrays, keyed club responses (`body[clubId]`), or `{ matches }` wrappers in `services/eaApi.js` and deduplicates by `matchId`/`matchid`/`id`.
- Add helper functions `isMatchPayload`, `getMatchPayloadId`, `appendUniqueMatch`, and `collectMatchesPayload` to encapsulate detection, id extraction, de-duplication, and recursive collection logic in `services/eaApi.js`.
- Add regression tests to `test/eaApi.test.js` that verify nested/duplicated EA match arrays are flattened and deduplicated, and to `test/server.test.js` that a supplied Club Alucin DNF-shaped payload normalizes to the official club `score`/result.
- Files changed: `services/eaApi.js`, `test/eaApi.test.js`, and `test/server.test.js`.

### Testing
- Ran the full test suite with `npm test` (Node.js test runner) and all automated tests passed.
- Test run summary: all tests completed successfully (regression tests covering nested payload flattening and the Club Alucin DNF case were added and passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a279b0d2e30832aa8683156dec9ac32)