### PR TITLE
Filter player stats to official league matches

### DIFF
--- a/db.js
+++ b/db.js
@@ -2,6 +2,47 @@ let pool;
 let tableReadyPromise;
 let playerStatsReadyPromise;
 
+const LEAGUE_CLUBS = [
+  { id: '57985', name: 'Bota FC', aliases: ['Bota FC', 'Bota'] },
+  { id: '6297844', name: 'Inferign United', aliases: ['Inferign United', 'Inferign Utd'] },
+  { id: '1171188', name: 'True Egoistas', aliases: ['True Egoistas', 'Egoistas'] },
+  { id: '4671025', name: 'Versus One', aliases: ['Versus One'] },
+  { id: '654142', name: 'FC Wisconsin', aliases: ['FC Wisconsin', 'FC Wisconson'] },
+  { id: '129307', name: 'FC Sutton St', aliases: ['FC Sutton St', 'FC Sutton'] },
+];
+
+function normalizeLeagueClubName(name) {
+  return String(name || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\butd\b/g, 'united')
+    .replace(/\bst\b/g, 'st')
+    .replace(/\s+/g, ' ');
+}
+
+function getLeagueClubAliasRows() {
+  return LEAGUE_CLUBS.flatMap(club => club.aliases.map(alias => ({
+    club_id: club.id,
+    club_name: club.name,
+    alias: normalizeLeagueClubName(alias),
+  })));
+}
+
+function getLeagueClubAliasSql() {
+  return getLeagueClubAliasRows()
+    .map((_, index) => `($${index * 3 + 1}, $${index * 3 + 2}, $${index * 3 + 3})`)
+    .join(', ');
+}
+
+function getLeagueClubAliasParams() {
+  return getLeagueClubAliasRows().flatMap(row => [row.club_id, row.club_name, row.alias]);
+}
+
+function getSqlNormalizedName(column) {
+  return `regexp_replace(lower(trim(COALESCE(${column}, ''))), '\\s+', ' ', 'g')`;
+}
+
+
 function getDatabaseUrl() {
   return process.env.DATABASE_URL;
 }
@@ -126,10 +167,25 @@ async function ensurePlayerStatsTables() {
 
 async function getPlayerStats() {
   await ensurePlayerStatsTables();
+  const aliasParams = getLeagueClubAliasParams();
   const response = await query(`
+    WITH league_club_aliases(club_id, club_name, normalized_alias) AS (
+      VALUES ${getLeagueClubAliasSql()}
+    ), official_league_matches AS (
+      SELECT m.match_id
+      FROM matches m
+      INNER JOIN league_club_aliases home_club
+        ON ${getSqlNormalizedName('m.club_name')} = home_club.normalized_alias
+      INNER JOIN league_club_aliases away_club
+        ON ${getSqlNormalizedName('m.opponent_name')} = away_club.normalized_alias
+      WHERE m.status = 'approved'
+        AND m.competition = 'league'
+        AND home_club.club_id <> away_club.club_id
+    )
     SELECT
       pms.player_name,
       COALESCE(MAX(NULLIF(pms.club_name, '')), '') AS club_name,
+      COUNT(DISTINCT pms.match_id)::integer AS league_matches,
       COUNT(DISTINCT pms.match_id)::integer AS matches_played,
       COALESCE(SUM(pms.goals), 0)::integer AS goals,
       COALESCE(SUM(pms.assists), 0)::integer AS assists,
@@ -147,12 +203,10 @@ async function getPlayerStats() {
       END::float AS tackle_percentage,
       COALESCE(SUM(CASE WHEN pms.man_of_the_match THEN 1 ELSE 0 END), 0)::integer AS motm_count
     FROM player_match_stats pms
-    INNER JOIN matches m ON m.match_id = pms.match_id
-    WHERE m.status = 'approved'
-      AND m.competition = 'league'
+    INNER JOIN official_league_matches olm ON olm.match_id = pms.match_id
     GROUP BY COALESCE(pms.ea_player_id, pms.player_name), pms.player_name
     ORDER BY goals DESC, assists DESC, motm_count DESC, pms.player_name ASC
-  `);
+  `, aliasParams);
   return response.rows;
 }
 
@@ -554,6 +608,8 @@ module.exports = {
   insertMatch,
   normalizeMatchDate,
   normalizePlayerMatchStats,
+  normalizeLeagueClubName,
+  getLeagueClubAliasRows,
   resetApprovedMatches,
   rejectMatch,
 };

--- a/public/teams.html
+++ b/public/teams.html
@@ -2102,8 +2102,8 @@
     function renderPlayerStatsLeaders(players) {
       const leaders = [
         ['Top Scorer', getLeader(players, 'goals'), player => String(player.goals)],
-        ['Top Assister', getLeader(players, 'assists'), player => String(player.assists)],
-        ['Best Passer', getLeader(players, 'pass_percentage'), player => formatPercentage(player.pass_percentage)],
+        ['Top Playmaker', getLeader(players, 'assists'), player => String(player.assists)],
+        ['Best Pass %', getLeader(players, 'pass_percentage'), player => formatPercentage(player.pass_percentage)],
         ['Best Tackler', getLeader(players, 'tackle_percentage'), player => formatPercentage(player.tackle_percentage)],
         ['Most MOTM', getLeader(players, 'motm_count'), player => String(player.motm_count)]
       ];
@@ -2120,14 +2120,14 @@
         <div class="table-wrap">
           <table class="standings player-stats-table">
             <thead>
-              <tr><th>Player</th><th>Club</th><th>MP</th><th>G</th><th>A</th><th>Pass %</th><th>Tackle %</th><th>MOTM</th></tr>
+              <tr><th>Player</th><th>Club</th><th>League Matches</th><th>Goals</th><th>Assists</th><th>Pass %</th><th>Tackle %</th><th>MOTM</th></tr>
             </thead>
             <tbody>
               ${players.map(player => `
                 <tr>
                   <td class="player-cell">${escapeHtml(player.player_name)}</td>
                   <td class="club-cell-text">${escapeHtml(player.club_name || '—')}</td>
-                  <td>${Number(player.matches_played) || 0}</td>
+                  <td>${Number(player.league_matches ?? player.matches_played) || 0}</td>
                   <td>${Number(player.goals) || 0}</td>
                   <td>${Number(player.assists) || 0}</td>
                   <td class="percentage-cell">${escapeHtml(formatPercentage(player.pass_percentage))}</td>

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -115,3 +115,25 @@ test('normalizePlayerMatchStats uses EA nested player and club keys instead of m
   assert.equal(stats[0].tackles_made, 2);
   assert.equal(stats[0].man_of_the_match, false);
 });
+
+test('league club aliases include only registered UPCL teams for player stat filtering', () => {
+  const { getLeagueClubAliasRows, normalizeLeagueClubName } = require('../db');
+  const aliases = getLeagueClubAliasRows();
+  const normalizedAliases = aliases.map(row => row.alias);
+
+  assert.deepEqual(new Set(aliases.map(row => row.club_name)), new Set([
+    'Bota FC',
+    'Inferign United',
+    'True Egoistas',
+    'Versus One',
+    'FC Wisconsin',
+    'FC Sutton St',
+  ]));
+  assert.ok(normalizedAliases.includes(normalizeLeagueClubName('Bota')));
+  assert.ok(normalizedAliases.includes(normalizeLeagueClubName('Inferign Utd')));
+  assert.ok(normalizedAliases.includes(normalizeLeagueClubName('FC Sutton')));
+  assert.equal(normalizedAliases.includes(normalizeLeagueClubName('Unreal Madrid3')), false);
+  assert.equal(normalizedAliases.includes(normalizeLeagueClubName('CLT EA')), false);
+  assert.equal(normalizedAliases.includes(normalizeLeagueClubName('Da Bears FC')), false);
+  assert.equal(normalizedAliases.includes(normalizeLeagueClubName('Dont Mata FC')), false);
+});


### PR DESCRIPTION
### Motivation
- Ensure player leaderboards count only official UPCL league matches using the same filtering rules as standings so friendlies and non-UPCL clubs are excluded.
- Provide an explicit "League Matches" column and leader cards that reflect totals derived from approved league fixtures only.

### Description
- Added a `LEAGUE_CLUBS` list and normalization helpers (`normalizeLeagueClubName`, `getLeagueClubAliasRows`, `getLeagueClubAliasParams`, `getLeagueClubAliasSql`, `getSqlNormalizedName`) to canonicalize registered UPCL team names for matching. (`db.js`)
- Rewrote `getPlayerStats()` to aggregate player totals only for `official_league_matches` (a CTE that requires `m.status = 'approved'`, `m.competition = 'league'`, and both `club_name` and `opponent_name` resolve to different registered UPCL clubs). The query now returns `league_matches` while preserving `matches_played` for compatibility. (`db.js`)
- Updated the frontend Player Stats UI labels and table columns to show `League Matches`, `Goals`, `Assists`, `Pass %`, `Tackle %`, and `MOTM`, and changed leader cards to `Top Scorer`, `Top Playmaker`, `Most MOTM`, `Best Pass %`, and `Best Tackler`. (`public/teams.html`)
- Exported the new normalization helpers from the DB module and added a unit test that validates the registered-alias set excludes non-UPCL clubs. (`db.js`, `test/db.test.js`)

### Testing
- Ran the full test suite with `npm test` and all tests passed (27 tests, 0 failures).
- Added a unit test `league club aliases include only registered UPCL teams for player stat filtering` which passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28568d1030832a93144a689b2ac9fa)