### PR TITLE
Add SIL1 silhouette to roster player cards

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -1593,7 +1593,10 @@
 
     .roster-card-render {
       position: relative;
+      display: grid;
+      place-items: end center;
       min-height: 0;
+      overflow: hidden;
       border-bottom: 1px solid rgba(255, 255, 255, 0.1);
       background:
         linear-gradient(180deg, rgba(255, 255, 255, 0.06), transparent 48%),
@@ -1603,11 +1606,25 @@
     .roster-card-render::after {
       content: "";
       position: absolute;
+      z-index: 0;
       pointer-events: none;
       inset: auto 20px 16px;
       height: 42px;
       background: radial-gradient(ellipse at center, rgba(192, 0, 0, 0.28), transparent 68%);
       filter: blur(2px);
+    }
+
+    .roster-card-silhouette {
+      position: relative;
+      z-index: 1;
+      width: min(88%, 240px);
+      max-height: 108%;
+      align-self: end;
+      object-fit: contain;
+      object-position: center bottom;
+      filter: drop-shadow(0 18px 26px rgba(0, 0, 0, 0.62));
+      transform: translateY(10px);
+      user-select: none;
     }
 
     .roster-card-info {
@@ -4179,7 +4196,9 @@
       }
       return activeRoster.map((player, index) => `
         <article class="roster-player-card ${getRosterCardClass(index)}" data-player-index="${index}" tabindex="0">
-          <div class="roster-card-render" aria-hidden="true"></div>
+          <div class="roster-card-render" aria-hidden="true">
+            <img class="roster-card-silhouette" src="/assets/SIL1.png" alt="" loading="lazy">
+          </div>
           <div class="roster-card-info">
             <div class="roster-card-name">
               <strong>${escapeHtml(player.name)}</strong>


### PR DESCRIPTION
### Motivation
- Surface the existing silhouette art on each roster player card so cards display a consistent player silhouette when no photo is present.
- Ensure the silhouette sits inside the card layout, anchored at the card bottom and layered above the card glow so it reads like an integrated graphic.

### Description
- Inserted an `<img>` with `src="/assets/SIL1.png"` and class `roster-card-silhouette` into the roster card render markup in `public/teams.html` so every rendered player card includes the silhouette image.
- Updated card render CSS in `public/teams.html` by making `.roster-card-render` a grid container, adding `place-items: end center` and `overflow: hidden`, moving the card glow behind the image with a `z-index`, and adding a `.roster-card-silhouette` rule to size, position, and shadow the asset.
- Changes are limited to `public/teams.html` and only affect the roster player card visual area and template rendering.

### Testing
- Ran `npm test` and all automated tests passed (`31` tests, `0` failures).
- Started the server and verified the site responded to `GET /` and the silhouette asset responded to `GET /assets/SIL1.png` (HTTP `200` and non-empty image payload).
- Performed a smoke check of the rendered HTML to confirm the new `roster-card-silhouette` CSS and `<img>` appear in the page output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a291b1cbae4832aac5cdf52aa47157c)